### PR TITLE
EPSG:4326でなければ、事前に投影変換

### DIFF
--- a/processing/upload_vector_algorithm.py
+++ b/processing/upload_vector_algorithm.py
@@ -297,12 +297,14 @@ class UploadVectorAlgorithm(QgsProcessingAlgorithm):
         """Process layer geometry: convert to singlepart and reproject to EPSG:4326 in one step"""
         source_crs = layer.crs()
         target_crs = QgsCoordinateReferenceSystem("EPSG:4326")
-        
+
         # Check if CRS is valid
         if not source_crs.isValid():
             raise QgsProcessingException(
-                self.tr("The input layer has an undefined or invalid coordinate reference system. "
-                       "Please assign a valid CRS to the layer before uploading.")
+                self.tr(
+                    "The input layer has an undefined or invalid coordinate reference system. "
+                    "Please assign a valid CRS to the layer before uploading."
+                )
             )
 
         # If no processing needed, return original layer


### PR DESCRIPTION
Related #11 

### What I did（変更内容）

- EPSG:4326でなければ、事前に投影変換
- 投影変換とsinglepartへの変換はsinkを活用
- メソッド引数の型定義を充実させた

### Notes（連絡事項）

- 平面直角座標系かつマルチパートなポリゴンをアップロードできることを確認