### PR TITLE
ログイン画面が固まらないように修正

### DIFF
--- a/qgishub/auth_manager.py
+++ b/qgishub/auth_manager.py
@@ -1,7 +1,6 @@
 import base64
 import hashlib
 import json
-import os
 import random
 import string
 import threading
@@ -9,7 +8,7 @@ import time
 import urllib.parse
 import urllib.request
 from http.server import BaseHTTPRequestHandler, HTTPServer
-from typing import Any, Dict, Literal, Optional, Tuple
+from typing import Any, Dict, Optional, Tuple
 
 from PyQt5.QtCore import QObject, QTimer, pyqtSignal
 

--- a/ui/dialog_config.py
+++ b/ui/dialog_config.py
@@ -89,11 +89,11 @@ class DialogConfig(QDialog):
             self.labelUserInfo.setText("")
             self.buttonLogout.setEnabled(False)
 
-    def _on_auth_completed(self, success: bool, error: str):
+    def on_auth_completed(self, success: bool, error: str):
         """Handle authentication completion."""
         # Disconnect the signal to avoid multiple connections
         try:
-            self.auth_manager.auth_completed.disconnect(self._on_auth_completed)
+            self.auth_manager.auth_completed.disconnect(self.on_auth_completed)
         except TypeError:
             pass  # Already disconnected
 
@@ -152,7 +152,7 @@ class DialogConfig(QDialog):
                 return
 
             # Connect to auth_completed signal
-            self.auth_manager.auth_completed.connect(self._on_auth_completed)
+            self.auth_manager.auth_completed.connect(self.on_auth_completed)
 
             # Open the authorization URL in the default browser
             auth_url = result


### PR DESCRIPTION
Close #18 

### What I did

- UIが固まらないように、`QObject`と`pyqtSignal`を使用して非同期認証を実装
- 認証完了時にシグナルを発信し、UIを更新する処理を追加
- 従来のブロッキング方式から非同期方式に変更
- ログイン画面の見た目の修正（ログイン試行中はその状態がわかるようにする）

![image](https://github.com/user-attachments/assets/6cc25534-4478-4248-8294-e8dcba25ef5d)


### Notes

- 認証フローをテストするために、ログインボタンをクリックし、挙動を確認