### PR TITLE
ジオメトリタイプの整合性チェック機能の追加と共通処理のメソッド化

### DIFF
--- a/processing/algs/upload_vector_algorithm.py
+++ b/processing/algs/upload_vector_algorithm.py
@@ -274,6 +274,14 @@ class UploadVectorAlgorithm(QgsProcessingAlgorithm):
 
         return vector_type, is_multipart
 
+    def _is_geometry_type_consistent(self, geometry, expected_type):
+        """check if geometry type matches expected type"""
+        if not geometry:
+            return False
+
+        actual_type = QgsWkbTypes.geometryType(geometry.wkbType())
+        return actual_type == expected_type
+
     def _process_layer_geometry(
         self,
         layer: QgsVectorLayer,
@@ -379,10 +387,9 @@ class UploadVectorAlgorithm(QgsProcessingAlgorithm):
                             continue  # Skip unfixable parts
 
                     # Check geometry type consistency
-                    part_geom_type = QgsWkbTypes.geometryType(
-                        single_geometry_part.wkbType()
-                    )
-                    if part_geom_type != expected_geom_type:
+                    if not self._is_geometry_type_consistent(
+                        single_geometry_part, expected_geom_type
+                    ):
                         wrong_geometry_type += 1
                         continue  # Skip parts with wrong geometry type
 
@@ -403,8 +410,7 @@ class UploadVectorAlgorithm(QgsProcessingAlgorithm):
                     features_processed += 1
             else:
                 # Check geometry type consistency
-                geom_type = QgsWkbTypes.geometryType(geom.wkbType())
-                if geom_type != expected_geom_type:
+                if not self._is_geometry_type_consistent(geom, expected_geom_type):
                     wrong_geometry_type += 1
                     continue  # Skip features with wrong geometry type
 


### PR DESCRIPTION
Close #25

### What I did（変更内容）

- ジオメトリタイプの整合性をチェックする機能を追加
  - ジオメトリの修正により、ゴミデータがラインとして生成されていた（地物としてQGISには表示できないようなもの）
  - レイヤタイプと異なるジオメトリがあれば、スキップすることとした。


### Notes（連絡事項）

- 01204_旭川市_公共座標12系_筆R.shpのデータでテストを実施
- 元データと地物数が同一なることを確認
- 見た目の描画も変わらず

![image](https://github.com/user-attachments/assets/6e4c1a2d-622a-45dd-92d7-79643b4b00f0)