### PR TITLE
スタイルマップに成功とエラーメッセージを追加

### DIFF
--- a/browser/styledmap.py
+++ b/browser/styledmap.py
@@ -86,9 +86,6 @@ class StyledMapItem(QgsDataItem):
                     None, "Error", f"Failed to load map '{self.styled_map.name}'."
                 )
         except Exception as e:
-            QgsMessageLog.logMessage(
-                f"スタイル適用エラー: {str(e)}", LOG_CATEGORY, Qgis.Critical
-            )
             QMessageBox.critical(None, "Error", f"Error loading map: {str(e)}")
 
     def handleDoubleClick(self):
@@ -153,14 +150,11 @@ class StyledMapItem(QgsDataItem):
                             f"Map '{new_name}' has been updated successfully.",
                         )
                     else:
-                        QgsMessageLog.logMessage(
-                            "Mapの上書き保存に失敗しました", LOG_CATEGORY, Qgis.Critical
-                        )
                         QMessageBox.critical(None, "Error", "Failed to update the map.")
 
         except Exception as e:
             QgsMessageLog.logMessage(
-                f"スタイルマップ編集エラー: {str(e)}", LOG_CATEGORY, Qgis.Critical
+                f"Error updating map: {str(e)}", LOG_CATEGORY, Qgis.Critical
             )
             QMessageBox.critical(None, "Error", f"Error updating map: {str(e)}")
 
@@ -186,9 +180,6 @@ class StyledMapItem(QgsDataItem):
                 f"Map '{self.styled_map.name}' has been saved successfully.",
             )
         else:
-            QgsMessageLog.logMessage(
-                "Mapの上書き保存に失敗しました", LOG_CATEGORY, Qgis.Critical
-            )
             QMessageBox.critical(None, "Error", "Failed to save the map.")
 
     def delete_styled_map(self):
@@ -215,14 +206,11 @@ class StyledMapItem(QgsDataItem):
                         f"Map '{self.styled_map.name}' has been deleted successfully.",
                     )
                 else:
-                    QgsMessageLog.logMessage(
-                        "Mapの削除に失敗しました", LOG_CATEGORY, Qgis.Critical
-                    )
                     QMessageBox.critical(None, "Error", "Failed to delete the map.")
 
         except Exception as e:
             QgsMessageLog.logMessage(
-                f"Map削除エラー: {str(e)}", LOG_CATEGORY, Qgis.Critical
+                f"Error deleting map: {str(e)}", LOG_CATEGORY, Qgis.Critical
             )
             QMessageBox.critical(None, "Error", f"Error deleting map: {str(e)}")
 


### PR DESCRIPTION
Close #26 

### What I did（変更内容）

- スタイルマップ作成時の成功と失敗のメッセージをQMessageBoxで表示するように修正
- スタイルマップの適用、更新、削除時に成功とエラーメッセージをQMessageBoxとiface.messageBarで表示するように修正
- スタイルマップの保存成功メッセージをQMessageBoxで表示するように修正

### Notes（連絡事項）

![image](https://github.com/user-attachments/assets/53c20b2a-0467-4074-b1c0-a2cbc5787b48)
