### PR TITLE
一時ファイルの作成方法を修正し、WindowsでMaps機能を機能するように修正

### DIFF
--- a/browser/styledmap.py
+++ b/browser/styledmap.py
@@ -343,11 +343,7 @@ def get_qgisproject_str() -> str:
         with open(tmp_path, "r", encoding="utf-8") as f:
             return f.read()
     finally:
-        if os.path.exists(tmp_path):
-            os.remove(tmp_path)
-            QgsMessageLog.logMessage(
-                f"Temporary file {tmp_path} removed.", LOG_CATEGORY, Qgis.Info
-            )
+        _delete_tempfile(tmp_path)
 
 
 def load_project_from_xml(xml_string: str) -> bool:
@@ -362,8 +358,16 @@ def load_project_from_xml(xml_string: str) -> bool:
         res = project.read(tmp_path)
         return res
     finally:
-        if os.path.exists(tmp_path):
-            os.remove(tmp_path)
-            QgsMessageLog.logMessage(
-                f"Temporary file {tmp_path} removed.", LOG_CATEGORY, Qgis.Info
-            )
+        _delete_tempfile(tmp_path)
+
+
+def _delete_tempfile(tmp_path: str):
+    if os.path.exists(tmp_path):
+        os.remove(tmp_path)
+        QgsMessageLog.logMessage(
+            f"Temporary file {tmp_path} removed.", LOG_CATEGORY, Qgis.Info
+        )
+    else:
+        QgsMessageLog.logMessage(
+            f"Temporary file {tmp_path} does not exist.", LOG_CATEGORY, Qgis.Warning
+        )


### PR DESCRIPTION
Close #9 

### What I did

- 一時ファイルをdelete=Falseにした

以下らしいです
> Windowsでtempfile.TemporaryFileを使用する際に発生する典型的な問題です。Windowsでは、TemporaryFileで作成されたファイルが他のプロセスから読み書きできないという制限があります。
解決策として、tempfile.NamedTemporaryFileを使用し、delete=Falseを指定してファイルを明示的に削除するように修正してください。

### Notes

- windowsでMaps機能が動作することを確認