### PR TITLE
通信にQgsBlockingNetworkRequestを利用（patchを除く）

### DIFF
--- a/qgishub/api/client.py
+++ b/qgishub/api/client.py
@@ -84,7 +84,7 @@ class ApiClient:
 
         # Execute request
         blocking_request = QgsBlockingNetworkRequest()
-        err = blocking_request.get(req)
+        err = blocking_request.get(req, forceRefresh=True)
 
         if err != QgsBlockingNetworkRequest.NoError:
             error_msg = blocking_request.errorMessage()
@@ -121,7 +121,9 @@ class ApiClient:
 
         if err != QgsBlockingNetworkRequest.NoError:
             error_msg = blocking_request.errorMessage()
-            return ApiClient.handle_blocking_reply(QByteArray(), error_msg)
+            return ApiClient.handle_blocking_reply(
+                QByteArray(), error_msg, forceRefresh=True
+            )
 
         reply = blocking_request.reply()
         return ApiClient.handle_blocking_reply(reply.content(), "")
@@ -181,7 +183,7 @@ class ApiClient:
 
         # Execute request
         blocking_request = QgsBlockingNetworkRequest()
-        err = blocking_request.deleteResource(req)
+        err = blocking_request.deleteResource(req, forceRefresh=True)
 
         if err != QgsBlockingNetworkRequest.NoError:
             error_msg = blocking_request.errorMessage()


### PR DESCRIPTION
Close #8 

### What I did（変更内容）

- 非同期処理の問題を解決するために、QgsBlockingNetworkRequestを利用
- これは、QEventLoopを使うと、属性テーブルが利用するスレッドに干渉するため
- 一方、QgsBlockingNetworkRequestはpatchがないので、QgsNetworkAccessManagerおよびQEventLoopを引き続き利用する。

エンドポイントの実装をいじって、QgsBlockingNetworkRequestを統一して利用できるようにするのもありかもしれない。

### Notes（連絡事項）

- 5万件の属性テーブルを開けることを確認
- 地物の追加、削除できることを確認
- レイヤおよびMapsの名前を変更できることを確認（patchが動作するか確認）