### PR TITLE
fix: デフォルト設定をDataClassで一度だけ定義・デフォルトの向け先をステージング環境に

### DIFF
--- a/qgishub/config.py
+++ b/qgishub/config.py
@@ -6,7 +6,7 @@ from qgishub.constants import LOG_CATEGORY
 from settings_manager import SettingsManager
 
 
-@dataclass(init=False)
+@dataclass(init=False, frozen=True)
 class DefaultConfig:
     COGNITO_URL: str = "https://strato-staging.auth.ap-northeast-1.amazoncognito.com"
     COGNITO_CLIENT_ID: str = "4us5qd97e5f471pdq7kk44d63s"


### PR DESCRIPTION
タイトルのとおり
テストではステージング環境を利用することに決めたので、所要の設定をしました