### PR TITLE
トークンの初期化と設定の更新

### DIFF
--- a/browser/root.py
+++ b/browser/root.py
@@ -90,7 +90,10 @@ class RootCollection(QgsDataCollectionItem):
 
         if result:
             # Refresh to show projects
-            self.refresh()
+            try:
+                self.refresh()
+            except Exception:
+                iface.browserModel().reload()
 
     def select_project(self):
         """Select a project to display"""

--- a/qgishub/api/auth.py
+++ b/qgishub/api/auth.py
@@ -10,6 +10,32 @@ from qgis.core import QgsNetworkAccessManager
 from ..config import config as qgishub_config
 
 
+def clear_tokens() -> bool:
+    """
+    すべてのトークンと認証情報を初期化し、何もない状態にする
+
+    Returns:
+        初期化が成功した場合True、失敗した場合False
+    """
+    try:
+        from settings_manager import SettingsManager
+
+        settings_manager = SettingsManager()
+
+        # 認証関連の設定をすべて空にする
+        settings_manager.store_setting("id_token", "")
+        settings_manager.store_setting("refresh_token", "")
+        settings_manager.store_setting("token_expires_at", "")
+        settings_manager.store_setting("user_info", {})
+        settings_manager.store_setting("selected_organization_id", "")
+        settings_manager.store_setting("selected_project_id", "")
+
+        return True
+    except Exception as e:
+        print(f"Error occurred during token initialization: {str(e)}")
+        return False
+
+
 def refresh_token(refresh_token: str) -> Optional[Dict]:
     """
     Cognitoを使用して期限切れのトークンをリフレッシュトークンで更新する

--- a/qgishub/auth_manager.py
+++ b/qgishub/auth_manager.py
@@ -177,6 +177,8 @@ class AuthManager(QObject):
             self.server.auth_code = None
             self.server.state = None
             self.server.redirect_url = REDIRECT_URL
+            # Get latest config values dynamically
+            qgishub_config.load_settings()
             self.server.cognito_url = qgishub_config.COGNITO_URL
             self.server.client_id = qgishub_config.COGNITO_CLIENT_ID
             self.server.code_verifier = self.code_verifier
@@ -270,6 +272,9 @@ class AuthManager(QObject):
         # Start local server
         if not self.start_local_server():
             return False, f"Failed to start local server: {self.error}"
+
+        # Get latest config values for authorization URL
+        qgishub_config.load_settings()
 
         # Get authorization URL with the same state parameter
         auth_url = (

--- a/qgishub/config.py
+++ b/qgishub/config.py
@@ -33,6 +33,10 @@ class Config:
         """設定マネージャーから設定を読み込む"""
         # プラグインがロードされている場合のみ設定を読み込む
         try:
+            # Lazy import to avoid circular dependency
+            from .api import auth
+
+            auth.clear_tokens()
             settings_manager = SettingsManager()
 
             # カスタムサーバー設定を読み込む

--- a/ui/dialog_config.py
+++ b/ui/dialog_config.py
@@ -175,6 +175,7 @@ class DialogConfig(QDialog):
 
             # Open the authorization URL in the default browser
             auth_url = result
+            print(f"Opening browser to: {auth_url}")  # For debugging
             QgsMessageLog.logMessage(
                 f"Opening browser to: {auth_url}", LOG_CATEGORY, Qgis.Info
             )
@@ -212,6 +213,7 @@ class DialogConfig(QDialog):
             settings_manager = SettingsManager()
             settings_manager.store_setting("id_token", "")
             settings_manager.store_setting("refresh_token", "")
+            settings_manager.store_setting("token_expires_at", "")
             settings_manager.store_setting("user_info", "")
             settings_manager.store_setting("selected_project_id", "")
 


### PR DESCRIPTION
Close #

### What I did（変更内容）

- トークンと認証情報を初期化する関数を追加

- 設定マネージャーから設定を読み込む際にトークンをクリア

- 認証URLを取得する際に最新の設定値を動的に取得

- エラーハンドリングを追加して、トークン初期化時の問題をログに記録

### Notes（連絡事項）

- トークンの初期化が正しく行われるかを確認するために、関連する機能をテストしてください。