### PR TITLE
［プロジェクトを選択］ボタンがQt6環境では動作しない

### DIFF
--- a/browser/root.py
+++ b/browser/root.py
@@ -118,7 +118,7 @@ class RootCollection(QgsDataCollectionItem):
 
             # Show project selection dialog
             dialog = ProjectSelectDialog()
-            result = dialog.exec_()
+            result = exec_dialog(dialog)
 
             if result:
                 # Get selected project


### PR DESCRIPTION
- `exec_dialog` 関数を使用していないことによるQt6互換性の問題でボタンが動作していなかったので修正

<img width="319" height="161" alt="スクリーンショット 2025-08-20 0 20 43" src="https://github.com/user-attachments/assets/8de8575c-1160-404e-85d6-5663a17ce4a6" />

