### PR TITLE
fix: カスタムサーバーのURLには/apiを含まない

### DIFF
--- a/strato/api/client.py
+++ b/strato/api/client.py
@@ -35,7 +35,7 @@ class ApiClient:
         """
         _api_config = api_config.get_api_config()
         # Build URL with query parameters if provided
-        url = f"{_api_config.API_URL}{endpoint}"
+        url = f"{_api_config.SERVER_URL}/api{endpoint}"
         if params:
             query_items = []
             for key, value in params.items():
@@ -75,7 +75,7 @@ class ApiClient:
             dict: {"content": dict, "error": None} or {"content": None, "error": str}
         """
         _api_config = api_config.get_api_config()
-        url = f"{_api_config.API_URL}{endpoint}"
+        url = f"{_api_config.SERVER_URL}/api{endpoint}"
 
         # Create request with authorization header
         req = QNetworkRequest(QUrl(url))
@@ -115,7 +115,7 @@ class ApiClient:
             dict: {"content": dict, "error": None} or {"content": None, "error": str}
         """
         _api_config = api_config.get_api_config()
-        url = f"{_api_config.API_URL}{endpoint}"
+        url = f"{_api_config.SERVER_URL}/api{endpoint}"
 
         # Create request with authorization header
         req = QNetworkRequest(QUrl(url))
@@ -154,7 +154,7 @@ class ApiClient:
             dict: {"content": dict, "error": None} or {"content": None, "error": str}
         """
         _api_config = api_config.get_api_config()
-        url = f"{_api_config.API_URL}{endpoint}"
+        url = f"{_api_config.SERVER_URL}/api{endpoint}"
 
         # Create request with authorization header
         req = QNetworkRequest(QUrl(url))

--- a/strato/api/config.py
+++ b/strato/api/config.py
@@ -1,20 +1,20 @@
 from abc import ABC
 from dataclasses import dataclass
 
-from settings_manager import get_settings, store_setting
+from settings_manager import get_settings
 
 DEFAULT_COGNITO_URL: str = (
     "https://strato-staging.auth.ap-northeast-1.amazoncognito.com"
 )
 DEFAULT_COGNITO_CLIENT_ID: str = "4us5qd97e5f471pdq7kk44d63s"
-DEFAULT_API_URL: str = "https://d28cu1u5by4hv7.cloudfront.net/api"
+DEFAULT_SERVER_URL: str = "https://d28cu1u5by4hv7.cloudfront.net"
 
 
 @dataclass(frozen=True)
 class ApiConfig(ABC):
     COGNITO_URL: str
     COGNITO_CLIENT_ID: str
-    API_URL: str
+    SERVER_URL: str
 
 
 def get_api_config() -> ApiConfig:
@@ -33,12 +33,12 @@ def get_api_config() -> ApiConfig:
         return ApiConfig(
             COGNITO_URL=custom_cognito_url,
             COGNITO_CLIENT_ID=custom_cognito_client_id,
-            API_URL=custom_server_url,
+            SERVER_URL=custom_server_url,
         )
     else:
         # デフォルト値
         return ApiConfig(
             COGNITO_URL=DEFAULT_COGNITO_URL,
             COGNITO_CLIENT_ID=DEFAULT_COGNITO_CLIENT_ID,
-            API_URL=DEFAULT_API_URL,
+            SERVER_URL=DEFAULT_SERVER_URL,
         )


### PR DESCRIPTION
<!-- Close or Related Issues -->
Close #0

### What I did
<!-- Please describe the motivation behind this PR and the changes it introduces. -->

- サーバー構成は、`http://hogefuga` -> Webページ　`http://hogefuga/api` -> APIサーバー という状態
- QGISからWebページに飛ばしたい時があるので、QGIS上のカスタムサーバーの設定値は`http://hogefuga`という、`/api`を含まない文字列とする

**なので、すでに設定値が存在する場合は`/api`を取り除かないと動かなくなるので注意**

### Notes
<!-- If manual testing is required, please describe the procedure. -->

