### PR TITLE
fix: QgsProject.readではなくiface.addProjectを使う

### DIFF
--- a/browser/styledmap.py
+++ b/browser/styledmap.py
@@ -485,14 +485,9 @@ def load_project_from_xml(xml_string: str) -> bool:
         tmp.write(xml_string)
         tmp_path = tmp.name
 
-        project = QgsProject.instance()
-        res = project.read(tmp_path)
-        return res
+        iface.addProject(tmp_path)
 
-    project = QgsProject.instance()
-    res = project.read(tmp_path)
     delete_tempfile(tmp_path)
-    return res
 
 
 def delete_tempfile(tmp_path: str):


### PR DESCRIPTION
<!-- Close or Related Issues -->
Close #179 

### What I did
<!-- Please describe the motivation behind this PR and the changes it introduces. -->

- Issueのワークアラウンドとして、qgsは`QgisInterface`を通じて開くことにする

### Notes
<!-- If manual testing is required, please describe the procedure. -->

