### PR TITLE
fix: warn switching project when project is dirty

### DIFF
--- a/browser/root.py
+++ b/browser/root.py
@@ -140,7 +140,7 @@ class RootCollection(QgsDataCollectionItem):
                 None,
                 self.tr("Change Project"),
                 self.tr(
-                    "Switching projects will discard the current map state, Continue?"
+                    "Switching projects will discard the current map state. Continue?"
                 ),
                 QMessageBox.Yes | QMessageBox.No,
                 QMessageBox.No,


### PR DESCRIPTION
<!-- Close or Related Issues -->
Close #198 

### What I did
<!-- Please describe the motivation behind this PR and the changes it introduces. -->

- QGISプロジェクトが未保存の場合は、プロジェクト選択前に警告を出す
- 従前と異なるProjectが選択された場合、プロジェクトをクリアする

### Notes
<!-- If manual testing is required, please describe the procedure. -->

