### PR TITLE
組織再選択時にOKボタンを無効化する

### DIFF
--- a/ui/dialog_project_select.py
+++ b/ui/dialog_project_select.py
@@ -322,6 +322,7 @@ class ProjectSelectDialog(QDialog):
         self.setMinimumWidth(500)
         self.selected_project = None
         self.current_org_id = None
+        self.previous_org_id = None
         self.current_user = None
         self.details_visible = False
         self.setup_ui()
@@ -557,6 +558,12 @@ class ProjectSelectDialog(QDialog):
         if index >= 0 and (
             org_data := self.account_org_panel["org_combo"].itemData(index)
         ):
+            # Only clear selection if organization actually changed
+            if self.previous_org_id is not None and self.previous_org_id != org_data.id:
+                self.selected_project = None
+                self.button_panel["ok_btn"].setEnabled(False)
+
+            self.previous_org_id = org_data.id
             self.load_organization_detail(org_data)
             self.load_projects(org_data)
 
@@ -727,7 +734,11 @@ class ProjectSelectDialog(QDialog):
     def load_projects(self, org: api.organization.Organization):
         """Load projects for the selected organization"""
         try:
+            # Clear the project list and reset selection
             self.project_section["project_list"].clear()
+            self.selected_project = None
+            self.button_panel["ok_btn"].setEnabled(False)
+
             projects = api.project.get_projects_by_organization(org.id)
 
             for project_item in projects:


### PR DESCRIPTION
<!-- Close or Related Issues -->
Close #206 

### What I did
<!-- Please describe the motivation behind this PR and the changes it introduces. -->

- 組織再選択時に、プロジェクトが選択されるまでOKボタンを無効化
- 組織の選択が変更されたらプロジェクトの選択をリセットし、再度プロジェクトが選択されるまでOKボタンを無効化している


### Notes
<!-- If manual testing is required, please describe the procedure. -->

