### PR TITLE
fix: treat integer as int64

### DIFF
--- a/strato/provider/dataprovider.py
+++ b/strato/provider/dataprovider.py
@@ -116,9 +116,9 @@ class StratoDataProvider(QgsVectorDataProvider):
             [
                 # INTEGER: 4-byte signed integer (-2147483648 to +2147483647)
                 QgsVectorDataProvider.NativeType(
-                    type=QVariant.Int,
+                    type=QVariant.LongLong,
                     typeDesc="Integer",
-                    subType=QVariant.Int,
+                    subType=QVariant.LongLong,
                     typeName="INTEGER",
                     minLen=0,  # Not applicable for integers
                     maxLen=0,  # Not applicable for integers
@@ -292,7 +292,7 @@ class StratoDataProvider(QgsVectorDataProvider):
 
     def fields(self) -> QgsFields:
         fs = QgsFields()
-        fs.append(QgsField("strato_id", QVariant.Int))
+        fs.append(QgsField("strato_id", QVariant.LongLong))
         if self.strato_vector is None:
             return fs
         for column in self.strato_vector.columns:


### PR DESCRIPTION
<!-- Close or Related Issues -->
Close #0

### What I did
<!-- Please describe the motivation behind this PR and the changes it introduces. -->

- gisdbのintegerは、strato_id含めて、全てBIGINTとして扱っているのでint64に統一

### Notes
<!-- If manual testing is required, please describe the procedure. -->

