### PR TITLE
Replace line break by underscore in attribute name

### DIFF
--- a/processing/upload_vector/normalize_field_name.py
+++ b/processing/upload_vector/normalize_field_name.py
@@ -5,10 +5,18 @@ def normalize_field_name(name: str, current_names: list[str]) -> str:
     """
     カラム名の正規化
     - 先頭と末尾の空白を削除
+    - 改行コードをアンダースコアに置換
     - 最大文字列長にカット
     - カット後に重複していたら連番を付与
     """
     normalized = name.strip()
+
+    # 改行コードをアンダースコアに置換
+    # Windowsの改行コードを先に処理
+    normalized = normalized.replace("\r\n", "_")
+    # 残りのケースを処理（1文字の場合）
+    normalized = normalized.replace("\n", "_")
+    normalized = normalized.replace("\r", "_")
 
     # 最大文字数制限
     if len(normalized) > MAX_FIELD_LENGTH:


### PR DESCRIPTION
<!-- Close or Related Issues -->
Close https://github.com/MIERUNE/strato-services/issues/812

### What I did
Replace line break by underscore in attribute name to avoid maplibre bug in webmap.

<!-- Please describe the motivation behind this PR and the changes it introduces. -->
<img width="1890" height="826" alt="image" src="https://github.com/user-attachments/assets/446bec11-b7cf-477e-8a3f-dae266c5194a" />




