### PR TITLE
[Windows] Fix white blank upload progress dialog

### DIFF
--- a/ui/browser/styledmap.py
+++ b/ui/browser/styledmap.py
@@ -756,7 +756,7 @@ class StyledMapRoot(QgsDataItem):
             progress_dialog.setValue(10)
             progress_dialog.show()
 
-            # Windows fix: ensure dialog is drawn properly
+            # Issue #356: ensure dialog is drawn properly on Windows
             progress_dialog.repaint()
             QCoreApplication.processEvents()
             progress_dialog.repaint()


### PR DESCRIPTION
<!-- Close or Related Issues -->
Close #356

### What I did
<!-- Please describe the motivation behind this PR and the changes it introduces. -->
- On Windows
- When Convert local project to kumoy

### Notes
<!-- If manual testing is required, please describe the procedure. -->
Probably due to interaction to processing.run() 
```
progress_dialog.repaint()
QCoreApplication.processEvents()
```
repeated twice to fix (once did not work)