### PR TITLE
fix: typeName() == "JSON"の場合の分岐・構造体と配列は明示的にto_json()

### DIFF
--- a/processing/upload_vector/algorithm.py
+++ b/processing/upload_vector/algorithm.py
@@ -14,7 +14,6 @@ from qgis.core import (
     QgsProcessingParameterField,
     QgsProcessingParameterString,
     QgsProcessingParameterVectorLayer,
-    QgsProject,
     QgsVectorLayer,
     QgsWkbTypes,
 )
@@ -348,8 +347,6 @@ class UploadVectorAlgorithm(QgsProcessingAlgorithm):
                 feedback,
                 selected_fields if selected_fields else None,
             )
-
-            QgsProject.instance().addMapLayer(normalized_layer)
 
             processed_layer = self._process_layer_geometry(
                 normalized_layer,


### PR DESCRIPTION
<!-- Close or Related Issues -->
Close #357 

### What I did
<!-- Please describe the motivation behind this PR and the changes it introduces. -->

- 上記Issueの原因：`native:extractbyexpression`にGeoJSONのJSON型のフィールドを突っ込むとエラーとなる
- 対処：上記Processingを実行するまでに、オンメモリのレイヤーのカラムを正規化しておく
- カラムの正規化の際、今まで暗黙的に実行されていたStringへの型変換を、`to_json`を用いて明示的に実行する

### Notes
<!-- If manual testing is required, please describe the procedure. -->

