### PR TITLE
Move Convert layer Action after the last separator position

### DIFF
--- a/plugin.py
+++ b/plugin.py
@@ -176,8 +176,27 @@ class KumoyPlugin:
         # Create and add convert action
         action = QAction(MAIN_ICON, self.tr("Convert to Kumoy Vector"), menu)
         action.triggered.connect(partial(on_convert_to_kumoy_clicked, layer))
-        menu.addSeparator()
-        menu.addAction(action)
+
+        # Actions to be added after the last separator
+        actions = menu.actions()
+        last_separator = None
+
+        for a in actions:
+            if a.isSeparator():
+                last_separator = a
+
+        if last_separator:
+            index = actions.index(last_separator)
+            if index + 1 < len(actions):
+                menu.insertAction(actions[index + 1], action)
+                menu.insertSeparator(actions[index + 1])
+            else:
+                menu.addAction(action)
+                menu.addSeparator()
+        else:
+            # Fallback: add to the end of the menu
+            menu.addSeparator()
+            menu.addAction(action)
 
     def initGui(self):
         self.dip = DataItemProvider()


### PR DESCRIPTION
<!-- Close or Related Issues -->
Close #366 

### What I did
<!-- Please describe the motivation behind this PR and the changes it introduces. -->
<img width="924" height="338" alt="image" src="https://github.com/user-attachments/assets/81ea1a00-aafd-4a63-93c9-a48509f49a16" />


### Notes
<!-- If manual testing is required, please describe the procedure. -->
- Layer menu default actions should have `objectName` attribute, but they are empty, making this approach hard.
