### PR TITLE
fix: cache clearはKumoy Vectorを開いていない場合にのみ実行可能

### DIFF
--- a/ui/browser/vector.py
+++ b/ui/browser/vector.py
@@ -614,7 +614,7 @@ class VectorRoot(QgsDataItem):
                     self.tr("Cache Clear Unavailable"),
                     self.tr(
                         "Cannot clear vector cache while vector layers are loaded on the map. "
-                        "Please remove all vector layers from the map first."
+                        "Please close your map first."
                     ),
                 )
                 return


### PR DESCRIPTION
<!-- Close or Related Issues -->
Close #395 

### What I did
<!-- Please describe the motivation behind this PR and the changes it introduces. -->

- 表示中のVectorのキャッシュをクリアするとリロード周りの複雑性を避けられないので、Vectorが地図上に存在する場合はキャッシュクリアできないようにした

### Notes
<!-- If manual testing is required, please describe the procedure. -->

