### PR TITLE
カスタムサーバー設定のトグルはデフォルトで閉じた状態にする

### DIFF
--- a/ui/dialog_login.py
+++ b/ui/dialog_login.py
@@ -117,7 +117,7 @@ class DialogLogin(QDialog):
         self.custom_server_config_group.setTitle(self.tr("Custom server configuration"))
         self.custom_server_config_group.setCheckable(True)
         self.custom_server_config_group.setChecked(False)
-        self.custom_server_config_group.setCollapsed(False)
+        self.custom_server_config_group.setCollapsed(True)
         self.custom_server_config_group.setSaveCheckedState(False)
 
         # Grid layout for server config


### PR DESCRIPTION
<!-- Close or Related Issues -->
Close #0

### What I did
<!-- Please describe the motivation behind this PR and the changes it introduces. -->


- 表題のとおり
- 開いていると、入力が必須のようにも見えるため閉じておきたい


### Notes
<!-- If manual testing is required, please describe the procedure. -->

