### PR TITLE
Correct indentation of success flag in vector cache clear

### DIFF
--- a/kumoy/local_cache/vector.py
+++ b/kumoy/local_cache/vector.py
@@ -336,7 +336,7 @@ def clear(vector_id: str) -> bool:
                     LOG_CATEGORY,
                     Qgis.Critical,
                 )
-            success = False  # Flag unsucceed
+                success = False
     # Delete last updated timestamp
     delete_last_updated(vector_id)
 


### PR DESCRIPTION


<!-- Close or Related Issues -->
Close #0

### What I did
<!-- Please describe the motivation behind this PR and the changes it introduces. -->

- Fix indentation bug in clear() where success = False was outside the except Exception block, causing cache clear to always report failure even on success

### Notes
<!-- If manual testing is required, please describe the procedure. -->

<img width="1059" height="73" alt="スクリーンショット 2026-03-12 13 42 37" src="https://github.com/user-attachments/assets/9f62f87e-1230-47fe-8df9-4783e7e12bea" />
