### PR TITLE
Fix QListWidget.Adjust compatibility for Qt6

### DIFF
--- a/pyqt_version.py
+++ b/pyqt_version.py
@@ -174,6 +174,10 @@ Qt6: QTextCursor.MoveOperation.End, QTextCursor.MoveOperation.Start, etc.
 """
 
 QDIALOG_CODE = QDialog if QT_VERSION_INT <= 5 else QDialog.DialogCode
+"""QDialog code class
+Qt5: QDialog.Accepted, QDialog.Rejected
+Qt6: QDialog.DialogCode.Accepted, QDialog.DialogCode.Rejected
+"""
 
 Q_LIST_VIEW_RESIZE_MODE = QListView if QT_VERSION_INT <= 5 else QListView.ResizeMode
 """QListView resize mode

--- a/pyqt_version.py
+++ b/pyqt_version.py
@@ -179,8 +179,8 @@ Qt5: QDialog.Accepted, QDialog.Rejected
 Qt6: QDialog.DialogCode.Accepted, QDialog.DialogCode.Rejected
 """
 
-Q_LIST_VIEW_RESIZE_MODE = QListView if QT_VERSION_INT <= 5 else QListView.ResizeMode
-"""QListView resize mode
+Q_LIST_VIEW = QListView if QT_VERSION_INT <= 5 else QListView.ResizeMode
+"""QListView
 Qt5: QListView.Adjust, QListView.Fixed, etc.
 Qt6: QListView.ResizeMode.Adjust, QListView.ResizeMode.Fixed, etc.
 """

--- a/pyqt_version.py
+++ b/pyqt_version.py
@@ -1,12 +1,13 @@
 """Qt5/Qt6 compatibility layer"""
 
-from qgis.PyQt.QtCore import QT_VERSION_STR, Qt, QBuffer
-from qgis.PyQt.QtGui import QRegion, QPainter, QTextCursor
+from qgis.PyQt.QtCore import QT_VERSION_STR, QBuffer, Qt
+from qgis.PyQt.QtGui import QPainter, QRegion, QTextCursor
 from qgis.PyQt.QtNetwork import QNetworkRequest
 from qgis.PyQt.QtWidgets import (
     QDialog,
     QDialogButtonBox,
     QLineEdit,
+    QListView,
     QMessageBox,
     QSizePolicy,
 )
@@ -173,9 +174,11 @@ Qt6: QTextCursor.MoveOperation.End, QTextCursor.MoveOperation.Start, etc.
 """
 
 QDIALOG_CODE = QDialog if QT_VERSION_INT <= 5 else QDialog.DialogCode
-"""QDialog code class
-Qt5: QDialog.Accepted, QDialog.Rejected
-Qt6: QDialog.DialogCode.Accepted, QDialog.DialogCode.Rejected
+
+Q_LIST_VIEW_RESIZE_MODE = QListView if QT_VERSION_INT <= 5 else QListView.ResizeMode
+"""QListView resize mode
+Qt5: QListView.Adjust, QListView.Fixed, etc.
+Qt6: QListView.ResizeMode.Adjust, QListView.ResizeMode.Fixed, etc.
 """
 
 

--- a/pyqt_version.py
+++ b/pyqt_version.py
@@ -179,8 +179,8 @@ Qt5: QDialog.Accepted, QDialog.Rejected
 Qt6: QDialog.DialogCode.Accepted, QDialog.DialogCode.Rejected
 """
 
-Q_LIST_VIEW = QListView if QT_VERSION_INT <= 5 else QListView.ResizeMode
-"""QListView
+Q_LIST_VIEW_RESIZE_MODE = QListView if QT_VERSION_INT <= 5 else QListView.ResizeMode
+"""QListView resize mode
 Qt5: QListView.Adjust, QListView.Fixed, etc.
 Qt6: QListView.ResizeMode.Adjust, QListView.ResizeMode.Fixed, etc.
 """

--- a/ui/dialog_project_select.py
+++ b/ui/dialog_project_select.py
@@ -32,12 +32,12 @@ from ..kumoy.constants import (
     LOG_CATEGORY,
 )
 from ..pyqt_version import (
+    Q_LIST_VIEW,
     Q_MESSAGEBOX_STD_BUTTON,
     QDIALOG_CODE,
     QT_ALIGN,
     QT_CUSTOM_CONTEXT_MENU,
     QT_LINEEDIT_ACTION_POSITION,
-    Q_LIST_VIEW_RESIZE_MODE,
     QT_NO_ITEM_FLAGS,
     QT_TEXT_FORMAT_PLAIN,
     QT_USER_ROLE,
@@ -293,7 +293,7 @@ class ProjectSelectDialog(QDialog):
 
         # Project list
         project_list = QListWidget()
-        project_list.setResizeMode(Q_LIST_VIEW_RESIZE_MODE.Adjust)
+        project_list.setResizeMode(Q_LIST_VIEW.Adjust)
         project_list.setSpacing(6)
         project_list.setStyleSheet(
             """

--- a/ui/dialog_project_select.py
+++ b/ui/dialog_project_select.py
@@ -37,6 +37,7 @@ from ..pyqt_version import (
     QT_ALIGN,
     QT_CUSTOM_CONTEXT_MENU,
     QT_LINEEDIT_ACTION_POSITION,
+    Q_LIST_VIEW_RESIZE_MODE,
     QT_NO_ITEM_FLAGS,
     QT_TEXT_FORMAT_PLAIN,
     QT_USER_ROLE,
@@ -292,7 +293,7 @@ class ProjectSelectDialog(QDialog):
 
         # Project list
         project_list = QListWidget()
-        project_list.setResizeMode(QListWidget.Adjust)
+        project_list.setResizeMode(Q_LIST_VIEW_RESIZE_MODE.Adjust)
         project_list.setSpacing(6)
         project_list.setStyleSheet(
             """

--- a/ui/dialog_project_select.py
+++ b/ui/dialog_project_select.py
@@ -32,7 +32,7 @@ from ..kumoy.constants import (
     LOG_CATEGORY,
 )
 from ..pyqt_version import (
-    Q_LIST_VIEW,
+    Q_LIST_VIEW_RESIZE_MODE,
     Q_MESSAGEBOX_STD_BUTTON,
     QDIALOG_CODE,
     QT_ALIGN,
@@ -293,7 +293,7 @@ class ProjectSelectDialog(QDialog):
 
         # Project list
         project_list = QListWidget()
-        project_list.setResizeMode(Q_LIST_VIEW.Adjust)
+        project_list.setResizeMode(Q_LIST_VIEW_RESIZE_MODE.Adjust)
         project_list.setSpacing(6)
         project_list.setStyleSheet(
             """


### PR DESCRIPTION
<!-- Close or Related Issues -->
Close #485 

### What I did
<!-- Please describe the motivation behind this PR and the changes it introduces. -->

- As a title.


### Notes
<!-- If manual testing is required, please describe the procedure. -->

- Please test if the project selection screen can still be opened from the Browser panel in QGIS 4.0.

