### PR TITLE
Save `kumoy_map_id` to custom variables when creating map

### DIFF
--- a/ui/browser/styledmap.py
+++ b/ui/browser/styledmap.py
@@ -567,6 +567,16 @@ class StyledMapRoot(QgsDataItem):
                 {"kumoy_map_id": new_styled_map.id}
             )
             QgsProject.instance().setTitle(new_styled_map.name)
+
+            # Save kumoy_map_id to project custom variables to link the new styled map
+            updated_qgisproject = write_qgsfile(new_styled_map.id)
+            api.styledmap.update_styled_map(
+                new_styled_map.id,
+                api.styledmap.UpdateStyledMapOptions(
+                    qgisproject=updated_qgisproject,
+                ),
+            )
+
             # reload browser panel
             self.parent().refresh()
 


### PR DESCRIPTION
<!-- Close or Related Issues -->
Close #495

### What I did
<!-- Please describe the motivation behind this PR and the changes it introduces. -->
`kumoy_map_id` was not saved to custom variables when creating map, making bugs when loading map

