### PR TITLE
ローカルキャッシュを vector.columns 順序非依存にする

### DIFF
--- a/kumoy/api/vector.py
+++ b/kumoy/api/vector.py
@@ -189,7 +189,7 @@ def get_vector(vector_id: str) -> KumoyVectorDetail:
         updatedAt=response.get("updatedAt", ""),
         extent=response.get("extent", []),
         count=response.get("count", 0),
-        columns=response.get("columns", []),
+        columns=sorted(response.get("columns", []), key=lambda c: c.get("name", "")),
         role=response.get("role", "MEMBER"),
     )
 

--- a/kumoy/local_cache/vector.py
+++ b/kumoy/local_cache/vector.py
@@ -193,6 +193,28 @@ def _update_existing_cache(cache_file: str, fields: QgsFields, diff: dict) -> st
     return updated_at
 
 
+def _cache_can_incrementally_sync(cache_file: str, intended: QgsFields) -> bool:
+    """既存 GPKG が intended の先頭一致なら、_update_existing_cache で末尾に
+    新規カラムを追加するだけで intended と物理順を揃えられる(regen 不要)。
+
+    True 例: cache=[kumoy_id, a, b], intended=[kumoy_id, a, b, c]
+    False 例:
+      - cache=[kumoy_id, c, a, b], intended=[kumoy_id, a, b, c]  (順序が違う)
+      - cache=[kumoy_id, a, b, x], intended=[kumoy_id, a, b]      (削除)
+      - cache=[kumoy_id, a, c],    intended=[kumoy_id, a, b, c]   (中間挿入)
+    False の場合は呼び出し側で regen させる前提。
+    """
+    layer = QgsVectorLayer(cache_file, "check_columns", "ogr")
+    if not layer.isValid():
+        return False
+    cache_names = list(layer.fields().names())
+    intended_names = list(intended.names())
+    del layer  # ファイルロックの解放
+    if len(cache_names) > len(intended_names):
+        return False
+    return intended_names[: len(cache_names)] == cache_names
+
+
 def sync_local_cache(
     vector_id: str,
     fields: QgsFields,
@@ -204,6 +226,7 @@ def sync_local_cache(
     - キャッシュはGPKGを用いる
     - ローカルにGPKGが存在しなければ新規で作成する
     - この関数の実行時、サーバー上のデータとの差分を取得してローカルのキャッシュを更新する
+    - 既存GPKGのカラム順が intended と一致しない場合は、キャッシュをクリアして新規作成し直す
     """
     cache_dir = _get_cache_dir()
     cache_file = os.path.join(cache_dir, f"{vector_id}.gpkg")
@@ -217,6 +240,24 @@ def sync_local_cache(
         # キャッシュファイルが存在しないが、最終更新日時が設定されている場合
         # 不整合が生じているので最終更新日時を削除する
         delete_last_updated(vector_id)
+        last_updated = None
+
+    # 既存キャッシュのカラム順が intended と乖離していて _update_existing_cache だけでは
+    # 揃え直せない場合は、GPKG を作り直す(SQLite ではカラム順を後から並べ替えることが
+    # 実用的にできないため、全件再ダウンロードで対応)。
+    # 末尾に新規カラムを追加するだけで揃うケース(=addAttributes 直後の同セッション)では
+    # regen は走らない。主に regen が走るのは:
+    #   (a) pre-change 時代の GPKG (順序未保証) からの移行 — 初回 1 回のみ
+    #   (b) addAttributes で末尾追加した GPKG を、API ソート順に揃え直す次セッション
+    if os.path.exists(cache_file) and not _cache_can_incrementally_sync(
+        cache_file, fields
+    ):
+        QgsMessageLog.logMessage(
+            f"Cache columns out of sync for vector {vector_id}, recreating cache file.",
+            LOG_CATEGORY,
+            Qgis.Info,
+        )
+        clear(vector_id)
         last_updated = None
 
     if os.path.exists(cache_file):

--- a/kumoy/local_cache/vector.py
+++ b/kumoy/local_cache/vector.py
@@ -143,6 +143,9 @@ def _update_existing_cache(cache_file: str, fields: QgsFields, diff: dict) -> st
         if vlayer.fields().indexOf(name) == -1:
             vlayer.addAttribute(QgsField(name, fields[name].type()))
 
+    # スキーマ調整後、vlayer.fields() の物理順序を確定させる
+    vlayer.updateFields()
+
     updated_at = datetime.datetime.now(datetime.timezone.utc).strftime(
         "%Y-%m-%dT%H:%M:%SZ"
     )
@@ -173,14 +176,14 @@ def _update_existing_cache(cache_file: str, fields: QgsFields, diff: dict) -> st
                 g.fromWkb(feature["kumoy_wkb"])
                 qgsfeature.setGeometry(g)
 
-                # Set attributes
-                qgsfeature.setFields(fields)
+                # サーバーの columns 返却順に依存しないよう、既存 GPKG の物理順 (vlayer.fields()) を信頼する
+                qgsfeature.setFields(vlayer.fields())
 
-                for name in fields.names():
+                for name in vlayer.fields().names():
                     if name == "kumoy_id":
                         qgsfeature["kumoy_id"] = feature["kumoy_id"]
                     else:
-                        qgsfeature[name] = feature["properties"][name]
+                        qgsfeature[name] = feature["properties"].get(name)
 
                 # Set feature ID and validity
                 qgsfeature.setValid(True)

--- a/kumoy/provider/dataprovider.py
+++ b/kumoy/provider/dataprovider.py
@@ -191,6 +191,10 @@ class KumoyDataProvider(QgsVectorDataProvider):
             else:
                 raise e
 
+        self._sync_cache_and_reload_layer()
+
+    def _sync_cache_and_reload_layer(self):
+        """Sync local GPKG cache against current self.kumoy_vector and reopen cached_layer."""
         # Show loading dialog for sync_local_cache operation
         progress = QProgressDialog(
             self.tr("Syncing: {}").format(self.kumoy_vector.name),
@@ -213,10 +217,12 @@ class KumoyDataProvider(QgsVectorDataProvider):
         sync_cancelled = False
         sync_error = None
 
-        # Create and configure worker thread
+        # Create and configure worker thread。
+        # cache 層には「サーバ正のあるべき schema」(=_intended_fields) を渡す。
+        # self.fields() は cached_layer の物理順を返すので、ここでは使わない。
         sync_worker = SyncWorker(
             self.kumoy_vector,
-            self.fields(),
+            self._intended_fields(),
             self.wkbType(),
         )
 
@@ -321,6 +327,12 @@ class KumoyDataProvider(QgsVectorDataProvider):
         return self.kumoy_vector.count
 
     def fields(self) -> QgsFields:
+        # GPKG とは sync_local_cache 側で常に順序を一致させる(不一致なら regen)
+        # ため、ここは kumoy_vector.columns 由来の intended をそのまま返してよい。
+        return self._intended_fields()
+
+    def _intended_fields(self) -> QgsFields:
+        """kumoy_vector.columns から組み立てたサーバ正の fields。"""
         fs = QgsFields()
         fs.append(QgsField("kumoy_id", QVariant.LongLong))
         if self.kumoy_vector is None:
@@ -521,7 +533,14 @@ class KumoyDataProvider(QgsVectorDataProvider):
         except Exception:
             return False
 
-        self._reload_vector()
+        # QGIS の edit buffer は新規追加フィールドを fields() の末尾に append される
+        # ことを前提に commit 整合性を検証する。get_vector() は API 層で columns を
+        # name 昇順に正規化するため、ここで _reload_vector() を呼ぶと末尾にならない
+        # 名前を追加したケースで commit が "Could not commit changes" で失敗する。
+        # サーバー再取得は行わず、kumoy_vector.columns に末尾追加してから
+        # ローカルキャッシュだけ同期する。
+        self.kumoy_vector.columns = list(self.kumoy_vector.columns) + attr_list
+        self._sync_cache_and_reload_layer()
         return True
 
     def deleteAttributes(self, attribute_ids: List[int]) -> bool:

--- a/tests/test_api_vector_columns_order.py
+++ b/tests/test_api_vector_columns_order.py
@@ -1,0 +1,56 @@
+"""kumoy.api.vector.get_vector が columns を name 昇順に正規化することを検証する."""
+
+from unittest.mock import patch
+
+
+def test_get_vector_sorts_columns_by_name():
+    from plugin_dir.kumoy.api import vector as api_vector
+
+    response = {
+        "id": "v1",
+        "name": "test",
+        "type": "POINT",
+        "projectId": "p1",
+        "project": {},
+        "attribution": "",
+        "storageUnits": 0,
+        "createdAt": "",
+        "updatedAt": "",
+        "extent": [],
+        "count": 0,
+        "role": "MEMBER",
+        "columns": [
+            {"name": "z_col", "type": "string"},
+            {"name": "a_col", "type": "integer"},
+            {"name": "m_col", "type": "float"},
+        ],
+    }
+
+    with patch.object(api_vector.ApiClient, "get", return_value=response):
+        result = api_vector.get_vector("v1")
+
+    assert [c["name"] for c in result.columns] == ["a_col", "m_col", "z_col"]
+
+
+def test_get_vector_handles_missing_columns():
+    from plugin_dir.kumoy.api import vector as api_vector
+
+    response = {
+        "id": "v1",
+        "name": "test",
+        "type": "POINT",
+        "projectId": "p1",
+        "project": {},
+        "attribution": "",
+        "storageUnits": 0,
+        "createdAt": "",
+        "updatedAt": "",
+        "extent": [],
+        "count": 0,
+        "role": "MEMBER",
+    }
+
+    with patch.object(api_vector.ApiClient, "get", return_value=response):
+        result = api_vector.get_vector("v1")
+
+    assert result.columns == []

--- a/tests/test_local_cache_vector_order.py
+++ b/tests/test_local_cache_vector_order.py
@@ -1,0 +1,213 @@
+"""_update_existing_cache が columns 順序ズレに対して堅牢であることを検証する.
+
+サーバーが返す columns の順序と既存 GPKG の物理カラム順が異なっていても、
+属性値が破損しない（名前ベースで正しく書き込まれる）ことを検証する。
+"""
+
+import os
+
+import pytest
+from qgis.core import (
+    QgsCoordinateReferenceSystem,
+    QgsFeature,
+    QgsField,
+    QgsFields,
+    QgsGeometry,
+    QgsProject,
+    QgsVectorFileWriter,
+    QgsVectorLayer,
+    QgsWkbTypes,
+)
+from qgis.PyQt.QtCore import QVariant
+
+
+def _build_fields(spec):
+    """spec: list of (name, QVariant_type) → QgsFields."""
+    fs = QgsFields()
+    for name, qtype in spec:
+        fs.append(QgsField(name, qtype))
+    return fs
+
+
+def _create_initial_gpkg(path: str, fields: QgsFields, initial_records: list) -> None:
+    """物理順 = fields の順序で GPKG を生成し、初期レコードを書き込む."""
+    options = QgsVectorFileWriter.SaveVectorOptions()
+    options.layerOptions = ["FID=kumoy_id"]
+    options.driverName = "GPKG"
+    options.fileEncoding = "UTF-8"
+    writer = QgsVectorFileWriter.create(
+        path,
+        fields,
+        QgsWkbTypes.Point,
+        QgsCoordinateReferenceSystem("EPSG:4326"),
+        QgsProject.instance().transformContext(),
+        options,
+    )
+    for rec in initial_records:
+        feat = QgsFeature()
+        feat.setGeometry(QgsGeometry.fromWkt("POINT(0 0)"))
+        feat.setFields(fields)
+        for name in fields.names():
+            feat[name] = rec[name]
+        feat.setValid(True)
+        writer.addFeature(feat)
+    del writer
+
+
+@pytest.mark.usefixtures("qgis_plugin_path")
+class TestUpdateExistingCacheOrder:
+    def _get_fn(self):
+        from plugin_dir.kumoy.local_cache.vector import _update_existing_cache
+
+        return _update_existing_cache
+
+    def test_reversed_server_order_does_not_corrupt_values(self, tmp_path):
+        """サーバーが返す columns 順を逆転しても、値が正しいカラムに書き込まれる."""
+        cache_file = str(tmp_path / "v.gpkg")
+
+        # 物理順 [kumoy_id, a, b] で既存 GPKG を作成（初期データ 1 行）
+        initial_fields = _build_fields(
+            [
+                ("kumoy_id", QVariant.LongLong),
+                ("a", QVariant.String),
+                ("b", QVariant.LongLong),
+            ]
+        )
+        _create_initial_gpkg(
+            cache_file,
+            initial_fields,
+            [{"kumoy_id": 1, "a": "OLD_A", "b": 100}],
+        )
+
+        # サーバ最新順を逆転 [kumoy_id, b, a] で fields を構築
+        server_fields = _build_fields(
+            [
+                ("kumoy_id", QVariant.LongLong),
+                ("b", QVariant.LongLong),
+                ("a", QVariant.String),
+            ]
+        )
+
+        wkb = QgsGeometry.fromWkt("POINT(1 1)").asWkb()
+        diff = {
+            "deletedRows": [],
+            "updatedRows": [
+                {
+                    "kumoy_id": 1,
+                    "kumoy_wkb": bytes(wkb),
+                    "properties": {"a": "VAL_A", "b": 99},
+                }
+            ],
+        }
+
+        self._get_fn()(cache_file, server_fields, diff)
+
+        # 結果検証: a 列に "VAL_A"、b 列に 99 が入っているべき
+        layer = QgsVectorLayer(cache_file, "v", "ogr")
+        assert layer.isValid()
+        feats = list(layer.getFeatures())
+        assert len(feats) == 1
+        feat = feats[0]
+        assert feat["a"] == "VAL_A"
+        assert feat["b"] == 99
+        assert feat["kumoy_id"] == 1
+        del layer
+        # ファイルロック解放のため明示的に削除
+        if os.path.exists(cache_file):
+            pass
+
+    def test_new_column_with_missing_property_is_null(self, tmp_path):
+        """サーバが新カラムを追加したが、当該行の properties にキーが無くても KeyError にならない."""
+        cache_file = str(tmp_path / "v.gpkg")
+
+        initial_fields = _build_fields(
+            [
+                ("kumoy_id", QVariant.LongLong),
+                ("a", QVariant.String),
+            ]
+        )
+        _create_initial_gpkg(
+            cache_file,
+            initial_fields,
+            [{"kumoy_id": 1, "a": "OLD_A"}],
+        )
+
+        # サーバ側で c カラムが追加された
+        server_fields = _build_fields(
+            [
+                ("kumoy_id", QVariant.LongLong),
+                ("a", QVariant.String),
+                ("c", QVariant.String),
+            ]
+        )
+
+        wkb = QgsGeometry.fromWkt("POINT(2 2)").asWkb()
+        diff = {
+            "deletedRows": [],
+            "updatedRows": [
+                {
+                    "kumoy_id": 1,
+                    "kumoy_wkb": bytes(wkb),
+                    "properties": {"a": "VAL_A"},  # c が欠損
+                }
+            ],
+        }
+
+        # KeyError が発生しないこと
+        self._get_fn()(cache_file, server_fields, diff)
+
+        layer = QgsVectorLayer(cache_file, "v", "ogr")
+        assert layer.isValid()
+        feats = list(layer.getFeatures())
+        assert len(feats) == 1
+        feat = feats[0]
+        assert feat["a"] == "VAL_A"
+        # c は NULL（None または NULL QVariant）
+        c_value = feat["c"]
+        assert c_value is None or (hasattr(c_value, "isNull") and c_value.isNull())
+
+    def test_deleted_column_is_removed(self, tmp_path):
+        """サーバ側でカラムが削除された場合、キャッシュからも削除され、他列値は破損しない."""
+        cache_file = str(tmp_path / "v.gpkg")
+
+        initial_fields = _build_fields(
+            [
+                ("kumoy_id", QVariant.LongLong),
+                ("a", QVariant.String),
+                ("b", QVariant.LongLong),
+            ]
+        )
+        _create_initial_gpkg(
+            cache_file,
+            initial_fields,
+            [{"kumoy_id": 1, "a": "OLD_A", "b": 100}],
+        )
+
+        # サーバで b カラムが削除された
+        server_fields = _build_fields(
+            [
+                ("kumoy_id", QVariant.LongLong),
+                ("a", QVariant.String),
+            ]
+        )
+
+        wkb = QgsGeometry.fromWkt("POINT(3 3)").asWkb()
+        diff = {
+            "deletedRows": [],
+            "updatedRows": [
+                {
+                    "kumoy_id": 1,
+                    "kumoy_wkb": bytes(wkb),
+                    "properties": {"a": "VAL_A"},
+                }
+            ],
+        }
+
+        self._get_fn()(cache_file, server_fields, diff)
+
+        layer = QgsVectorLayer(cache_file, "v", "ogr")
+        assert layer.isValid()
+        assert "b" not in layer.fields().names()
+        feats = list(layer.getFeatures())
+        assert len(feats) == 1
+        assert feats[0]["a"] == "VAL_A"


### PR DESCRIPTION
## 概要

ローカルキャッシュ（GPKG）が、サーバーから返される `vector.columns` 配列の **順序** に暗黙的に依存していた問題と、それに連鎖していたカラム追加時の commit 失敗・再起動後の値ズレ・VARCHAR 不一致警告を解消します。

3 commits に整理（draft PR #511 を清書再提出する位置付け）。各 commit が直交した目的を持ち、レビュー時に「どの問題に効くか」が辿れるようにしています。

## 設計の柱

`KumoyFeatureIterator` は `cached_layer.getFeatures()` から QgsFeature をそのまま QGIS に返す。QGIS は `provider.fields()` のインデックス基準で属性にアクセスするため、`provider.fields()` の物理順と `cached_layer.fields()` の物理順が**必ず一致**していないと値ズレが起きる。これを実現するための 3 段防御:

1. **API 層 sorted**: 「サーバ正の順序」を name 昇順に正規化（唯一の正準順序）
2. **Cache regen on drift**: GPKG 物理順が intended と先頭一致しなければ clear して再生成
3. **`_update_existing_cache` の name ベース書き込み**: regen が万一漏れても破損しないための最終防壁

## コミット構成

### Commit 1: ローカルキャッシュをサーバ列順序の変動から守る

`_update_existing_cache` 内の防衛のみ。これだけでも単発 sync 内では保護として完結する。

- `setFields(fields)` → `setFields(vlayer.fields())`（GPKG 物理順を信頼）
- 反復子も `vlayer.fields().names()` に
- `properties.get(name)` で新カラム未含有行の KeyError 防御
- `tests/test_local_cache_vector_order.py` 新規（3 ケース）

### Commit 2: API 層で columns を name 昇順に正規化、ズレたキャッシュは再生成

セッションをまたいで物理順を安定させる恒久対策。

- `kumoy/api/vector.py::get_vector()` で `columns` を name 昇順 sorted
- `kumoy/local_cache/vector.py`:
  - `_cache_can_incrementally_sync(cache_file, intended)` 新規（先頭一致判定）
  - `sync_local_cache()` に regen 分岐（不一致なら clear + 再生成）
- `tests/test_api_vector_columns_order.py` 新規（2 ケース）

### Commit 3: カラム追加時の commit 失敗を解消

QGIS edit buffer の前提（新規フィールドは末尾 append）と、API 層の sorted 正規化が衝突する問題を、addAttributes の経路で吸収。

- `_reload_vector()` の後半を `_sync_cache_and_reload_layer()` に抽出
- `addAttributes()`: API 再取得をやめ、`kumoy_vector.columns` 末尾追加 + `_sync_cache_and_reload_layer()` のみ
- `provider.fields()` は `_intended_fields()` を返す
- API 順への並び替えは次セッションの sync_local_cache（commit 2 の regen）に任せる

## テスト

ローカル Docker (`qgis/qgis:3.40` + xvfb) で全 100 件 pass（既存 95 + 新規 5）。

## 残っている検証項目（QGIS 実機）

1. 既存 pre-change GPKG を持ったままプラグイン更新 → レイヤー初回オープンで regen が走り正しく表示
2. name ソートで末尾にならない文字列カラム（例: 「かかかか」）追加→保存:
   - 「Could not commit changes」「属性が一致しません」が出ない
   - 値編集ができる
   - QGIS 再起動後、追加カラム位置が正しく、値もズレない
3. 末尾になるカラム（例: 既存 aaa, bbb に zzz）追加でも引き続き成功
4. 通常の地物編集だけのセッションで regen が走らない（QGIS の Log Messages → "Kumoy" カテゴリで `recreating cache file` が出ないこと）

## 関連

draft PR #511 を本 PR で清書再提出。マージ後は #511 をクローズします。