### PR TITLE
ローカルキャッシュのカラム順がサーバーと異なる場合に再生成する

### DIFF
--- a/kumoy/local_cache/vector.py
+++ b/kumoy/local_cache/vector.py
@@ -7,7 +7,6 @@ from qgis.core import (
     QgsApplication,
     QgsCoordinateReferenceSystem,
     QgsFeature,
-    QgsField,
     QgsFields,
     QgsGeometry,
     QgsMessageLog,
@@ -119,9 +118,52 @@ def _create_new_cache(
     return updated_at
 
 
+def _columns_match(cache_file: str, fields: QgsFields) -> bool:
+    """
+    キャッシュGPKGの物理カラム順とサーバー側 fields のカラム順を比較する。
+    kumoy_id は FID として特別扱いされるので比較対象から除外する。
+    一致すれば True、不一致なら False。GPKGがロードできない場合も False。
+    """
+    vlayer = QgsVectorLayer(cache_file, "tmp", "ogr")
+    if not vlayer.isValid():
+        del vlayer
+        return False
+
+    cache_names = [n for n in vlayer.fields().names() if n != "kumoy_id"]
+    server_names = [n for n in fields.names() if n != "kumoy_id"]
+    del vlayer
+
+    return cache_names == server_names
+
+
+def _recreate_cache(
+    cache_file: str,
+    vector_id: str,
+    fields: QgsFields,
+    geometry_type: QgsWkbTypes.GeometryType,
+    progress_callback: Optional[Callable[[int], None]],
+    reason: str,
+) -> str:
+    """既存キャッシュを破棄して新規作成する"""
+    QgsMessageLog.logMessage(
+        f"Recreating cache for vector {vector_id}: {reason}",
+        LOG_CATEGORY,
+        Qgis.Info,
+    )
+    clear(vector_id)
+    return _create_new_cache(
+        cache_file,
+        vector_id,
+        fields,
+        geometry_type,
+        progress_callback=progress_callback,
+    )
+
+
 def _update_existing_cache(cache_file: str, fields: QgsFields, diff: dict) -> str:
     """
-    既存のキャッシュファイルを更新する
+    既存のキャッシュファイルに差分を適用する。
+    カラム集合・順序の整合は呼び出し側で担保する前提（不一致なら再生成パスに入る）。
 
     Returns:
         updated_at: 最終更新日時
@@ -129,19 +171,6 @@ def _update_existing_cache(cache_file: str, fields: QgsFields, diff: dict) -> st
 
     vlayer = QgsVectorLayer(cache_file, "temp", "ogr")
     vlayer.startEditing()
-
-    # サーバーに存在しないカラムをキャッシュから削除
-    for cache_colname in vlayer.fields().names():
-        if cache_colname == "kumoy_id":
-            continue
-        # キャッシュにはあるが、現在のサーバー上のカラムには存在しないキャッシュのカラムを削除
-        if fields.indexOf(cache_colname) == -1:
-            vlayer.deleteAttribute(vlayer.fields().indexOf(cache_colname))
-
-    # サーバーだけに存在するカラムをキャッシュに追加
-    for name in fields.names():
-        if vlayer.fields().indexOf(name) == -1:
-            vlayer.addAttribute(QgsField(name, fields[name].type()))
 
     updated_at = datetime.datetime.now(datetime.timezone.utc).strftime(
         "%Y-%m-%dT%H:%M:%SZ"
@@ -222,29 +251,35 @@ def sync_local_cache(
             raise Exception(
                 "Inconsistent state: cache file exists but last_updated is None"
             )
-        try:
-            # memo: この処理は失敗しうる（e.g. 差分が大きすぎる場合）
-            diff = api.qgis_vector.get_diff(vector_id, last_updated)
-            # 差分取得でエラーがなかった場合は、得られた差分をキャッシュに適用する
-            updated_at = _update_existing_cache(cache_file, fields, diff)
-        except api.error.AppError as e:
-            if e.error == "MAX_DIFF_COUNT_EXCEEDED":
-                # 差分が大きすぎる場合はキャッシュファイルを削除して新規作成する
-                QgsMessageLog.logMessage(
-                    f"Diff for vector {vector_id} is too large, recreating cache file.",
-                    LOG_CATEGORY,
-                    Qgis.Info,
-                )
-                clear(vector_id)
-                updated_at = _create_new_cache(
-                    cache_file,
-                    vector_id,
-                    fields,
-                    geometry_type,
-                    progress_callback=progress_callback,
-                )
-            else:
-                raise e
+
+        if not _columns_match(cache_file, fields):
+            # 物理カラム順とサーバー順が一致しない → 再生成
+            updated_at = _recreate_cache(
+                cache_file,
+                vector_id,
+                fields,
+                geometry_type,
+                progress_callback,
+                reason="cache column order differs from server",
+            )
+        else:
+            try:
+                # memo: この処理は失敗しうる（e.g. 差分が大きすぎる場合）
+                diff = api.qgis_vector.get_diff(vector_id, last_updated)
+                # 差分取得でエラーがなかった場合は、得られた差分をキャッシュに適用する
+                updated_at = _update_existing_cache(cache_file, fields, diff)
+            except api.error.AppError as e:
+                if e.error == "MAX_DIFF_COUNT_EXCEEDED":
+                    updated_at = _recreate_cache(
+                        cache_file,
+                        vector_id,
+                        fields,
+                        geometry_type,
+                        progress_callback,
+                        reason="MAX_DIFF_COUNT_EXCEEDED",
+                    )
+                else:
+                    raise e
     else:
         # 新規キャッシュファイルを作成
         updated_at = _create_new_cache(

--- a/kumoy/local_cache/vector.py
+++ b/kumoy/local_cache/vector.py
@@ -150,7 +150,13 @@ def _recreate_cache(
         LOG_CATEGORY,
         Qgis.Info,
     )
-    clear(vector_id)
+    if not clear(vector_id):
+        # clear() がファイルロック等で失敗した場合、上書き作成も失敗するので
+        # 部分的な再生成で壊れた状態にしないように中断する
+        raise Exception(
+            f"Failed to clear cache for vector {vector_id} "
+            "(file may be locked by another process)"
+        )
     return _create_new_cache(
         cache_file,
         vector_id,

--- a/kumoy/local_cache/vector.py
+++ b/kumoy/local_cache/vector.py
@@ -285,7 +285,7 @@ def sync_local_cache(
                         reason="MAX_DIFF_COUNT_EXCEEDED",
                     )
                 else:
-                    raise e
+                    raise
     else:
         # 新規キャッシュファイルを作成
         updated_at = _create_new_cache(

--- a/kumoy/local_cache/vector.py
+++ b/kumoy/local_cache/vector.py
@@ -378,7 +378,11 @@ def clear(vector_id: str) -> bool:
                     Qgis.Critical,
                 )
                 success = False
-    # Delete last updated timestamp
-    delete_last_updated(vector_id)
+    # ファイル削除に失敗した状態で last_updated を消すと、GPKGは残るのに
+    # タイムスタンプだけ消える不整合状態になり、以後の同期が
+    # 'cache file exists but last_updated is None' で固まる。
+    # 削除が全件成功した場合のみタイムスタンプも消す。
+    if success:
+        delete_last_updated(vector_id)
 
     return success

--- a/kumoy/provider/dataprovider.py
+++ b/kumoy/provider/dataprovider.py
@@ -245,6 +245,12 @@ class KumoyDataProvider(QgsVectorDataProvider):
         sync_worker.progress.connect(on_worker_progress)
         progress.canceled.connect(on_progress_cancelled)
 
+        # sync 中に clear/再生成が走っても GPKG ファイルロックが残らないよう、
+        # 既存の cached_layer を sync 開始前に解放しておく（特にWindows対策）
+        if hasattr(self, "cached_layer") and self.cached_layer is not None:
+            del self.cached_layer
+            self.cached_layer = None
+
         # Start sync in background and wait for completion
         sync_worker.start()
         exec_event_loop(loop)  # This keeps UI responsive while waiting
@@ -269,11 +275,6 @@ class KumoyDataProvider(QgsVectorDataProvider):
                 ),
                 level=Qgis.Warning,
             )
-
-        # Delete existing cached_layer before reloading
-        if hasattr(self, "cached_layer") and self.cached_layer is not None:
-            # Force closing connection with GPKG file
-            del self.cached_layer
 
         self.cached_layer = local_cache.vector.get_layer(self.kumoy_vector.id)
 

--- a/kumoy/provider/dataprovider.py
+++ b/kumoy/provider/dataprovider.py
@@ -15,6 +15,7 @@ from qgis.core import (
     QgsProviderRegistry,
     QgsRectangle,
     QgsVectorDataProvider,
+    QgsVectorLayer,
     QgsWkbTypes,
 )
 from qgis.PyQt.QtCore import (
@@ -111,6 +112,7 @@ class KumoyDataProvider(QgsVectorDataProvider):
 
         # local cache
         self.kumoy_vector: Optional[api.vector.KumoyVectorDetail] = None
+        self.cached_layer: Optional[QgsVectorLayer] = None
         self._reload_vector()
 
         if self.kumoy_vector is None:
@@ -247,7 +249,7 @@ class KumoyDataProvider(QgsVectorDataProvider):
 
         # sync 中に clear/再生成が走っても GPKG ファイルロックが残らないよう、
         # 既存の cached_layer を sync 開始前に解放しておく（特にWindows対策）
-        if hasattr(self, "cached_layer") and self.cached_layer is not None:
+        if self.cached_layer is not None:
             del self.cached_layer
             self.cached_layer = None
 

--- a/plugin.py
+++ b/plugin.py
@@ -244,6 +244,10 @@ class KumoyPlugin:
                 str(e),
             )
             return
+        # provider.fields() がカラム順・追加・削除で変わっている可能性があるので、
+        # レイヤー側のフィールドキャッシュを更新し、属性テーブル等にも変更を通知する
+        layer.updateFields()
+        layer.dataChanged.emit()
         layer.triggerRepaint()
         self.iface.mapCanvas().refresh()
 

--- a/tests/test_local_cache_vector.py
+++ b/tests/test_local_cache_vector.py
@@ -235,6 +235,29 @@ class TestSyncLocalCache:
 
         assert s.calls["get_features"] == 0
 
+    def test_clear_preserves_last_updated_on_failure(self, sync_setup, monkeypatch):
+        """clear() がファイル削除に失敗した場合は last_updated を消さない。
+        消してしまうと GPKG だけ残って last_updated が None という不整合状態になり、
+        以降の sync_local_cache が 'cache file exists but last_updated is None'
+        パスに入り続けてしまう。
+        """
+        from plugin_dir.kumoy.local_cache.settings import get_last_updated
+
+        s = sync_setup
+        cache_file = os.path.join(s.cache_dir, f"{s.vector_id}.gpkg")
+        _make_gpkg(cache_file, ["a", "b"])
+        s.store_last_updated(s.vector_id, "2025-01-01T00:00:00Z")
+
+        def fail_unlink(path):
+            raise PermissionError(f"locked: {path}")
+
+        monkeypatch.setattr(s.vector_mod.os, "unlink", fail_unlink)
+
+        result = s.vector_mod.clear(s.vector_id)
+
+        assert result is False
+        assert get_last_updated(s.vector_id) == "2025-01-01T00:00:00Z"
+
     def test_recreates_on_max_diff_count_exceeded(self, sync_setup):
         s = sync_setup
         cache_file = os.path.join(s.cache_dir, f"{s.vector_id}.gpkg")

--- a/tests/test_local_cache_vector.py
+++ b/tests/test_local_cache_vector.py
@@ -218,6 +218,23 @@ class TestSyncLocalCache:
 
         assert get_last_updated(s.vector_id) is not None
 
+    def test_raises_when_clear_fails(self, sync_setup, monkeypatch):
+        s = sync_setup
+        cache_file = os.path.join(s.cache_dir, f"{s.vector_id}.gpkg")
+        _make_gpkg(cache_file, ["b", "a"])
+        s.store_last_updated(s.vector_id, "2025-01-01T00:00:00Z")
+
+        monkeypatch.setattr(s.vector_mod, "clear", lambda vid: False)
+
+        with pytest.raises(Exception, match="Failed to clear cache"):
+            s.vector_mod.sync_local_cache(
+                vector_id=s.vector_id,
+                fields=_build_fields(["a", "b"]),
+                geometry_type=QgsWkbTypes.Point,
+            )
+
+        assert s.calls["get_features"] == 0
+
     def test_recreates_on_max_diff_count_exceeded(self, sync_setup):
         s = sync_setup
         cache_file = os.path.join(s.cache_dir, f"{s.vector_id}.gpkg")

--- a/tests/test_local_cache_vector.py
+++ b/tests/test_local_cache_vector.py
@@ -1,0 +1,242 @@
+"""kumoy/local_cache/vector.py のテスト
+
+カラム順序チェック (_columns_match) と sync_local_cache の分岐挙動を検証する。
+"""
+
+import os
+import types
+
+import pytest
+from qgis.core import (
+    QgsCoordinateReferenceSystem,
+    QgsField,
+    QgsFields,
+    QgsGeometry,
+    QgsPointXY,
+    QgsProject,
+    QgsVectorFileWriter,
+    QgsWkbTypes,
+)
+from qgis.PyQt.QtCore import QVariant
+
+
+def _build_fields(column_names):
+    """kumoy_id 先頭 + 指定カラム名（全て String）の QgsFields を作る"""
+    fs = QgsFields()
+    fs.append(QgsField("kumoy_id", QVariant.LongLong))
+    for name in column_names:
+        fs.append(QgsField(name, QVariant.String))
+    return fs
+
+
+def _make_gpkg(path: str, column_names):
+    """テスト用に直接 GPKG を生成する"""
+    fields = _build_fields(column_names)
+    options = QgsVectorFileWriter.SaveVectorOptions()
+    options.layerOptions = ["FID=kumoy_id"]
+    options.driverName = "GPKG"
+    options.fileEncoding = "UTF-8"
+    writer = QgsVectorFileWriter.create(
+        path,
+        fields,
+        QgsWkbTypes.Point,
+        QgsCoordinateReferenceSystem("EPSG:4326"),
+        QgsProject.instance().transformContext(),
+        options,
+    )
+    assert writer.hasError() == QgsVectorFileWriter.NoError
+    del writer
+
+
+def _point_wkb(x: float, y: float) -> bytes:
+    g = QgsGeometry.fromPointXY(QgsPointXY(x, y))
+    return bytes(g.asWkb())
+
+
+@pytest.mark.usefixtures("qgis_plugin_path")
+class TestColumnsMatch:
+    def _fn(self):
+        from plugin_dir.kumoy.local_cache.vector import _columns_match
+
+        return _columns_match
+
+    def test_same_order(self, tmp_path):
+        gpkg = str(tmp_path / "x.gpkg")
+        _make_gpkg(gpkg, ["a", "b", "c"])
+        assert self._fn()(gpkg, _build_fields(["a", "b", "c"])) is True
+
+    def test_swapped_order(self, tmp_path):
+        gpkg = str(tmp_path / "x.gpkg")
+        _make_gpkg(gpkg, ["a", "b", "c"])
+        assert self._fn()(gpkg, _build_fields(["a", "c", "b"])) is False
+
+    def test_extra_in_cache(self, tmp_path):
+        gpkg = str(tmp_path / "x.gpkg")
+        _make_gpkg(gpkg, ["a", "b", "c", "extra"])
+        assert self._fn()(gpkg, _build_fields(["a", "b", "c"])) is False
+
+    def test_extra_on_server(self, tmp_path):
+        gpkg = str(tmp_path / "x.gpkg")
+        _make_gpkg(gpkg, ["a", "b"])
+        assert self._fn()(gpkg, _build_fields(["a", "b", "c"])) is False
+
+    def test_only_kumoy_id(self, tmp_path):
+        gpkg = str(tmp_path / "x.gpkg")
+        _make_gpkg(gpkg, [])
+        assert self._fn()(gpkg, _build_fields([])) is True
+
+    def test_missing_file(self, tmp_path):
+        gpkg = str(tmp_path / "missing.gpkg")
+        assert self._fn()(gpkg, _build_fields(["a"])) is False
+
+
+@pytest.mark.usefixtures("qgis_plugin_path")
+class TestSyncLocalCache:
+    """sync_local_cache の分岐挙動を検証する"""
+
+    @pytest.fixture
+    def sync_setup(self, tmp_path, monkeypatch):
+        from plugin_dir.kumoy import api as real_api
+        from plugin_dir.kumoy.local_cache import vector as vector_mod
+        from plugin_dir.kumoy.local_cache.settings import (
+            delete_last_updated,
+            store_last_updated,
+        )
+
+        cache_dir = tmp_path / "cache"
+        cache_dir.mkdir()
+        monkeypatch.setattr(vector_mod, "_get_cache_dir", lambda: str(cache_dir))
+
+        calls = {"get_features": 0, "get_diff": 0}
+
+        def default_get_features(vector_id, after_id=None):
+            return [
+                {
+                    "kumoy_id": 1,
+                    "kumoy_wkb": _point_wkb(0.0, 0.0),
+                    "properties": {"a": "v1", "b": "v2"},
+                }
+            ]
+
+        def default_get_diff(vector_id, last_updated):
+            return {"updatedRows": [], "deletedRows": []}
+
+        state = {
+            "get_features": default_get_features,
+            "get_diff": default_get_diff,
+        }
+
+        fake_qgis_vector = types.SimpleNamespace(
+            get_features=lambda **kwargs: (
+                calls.__setitem__("get_features", calls["get_features"] + 1)
+                or state["get_features"](**kwargs)
+            ),
+            get_diff=lambda *args, **kwargs: (
+                calls.__setitem__("get_diff", calls["get_diff"] + 1)
+                or state["get_diff"](*args, **kwargs)
+            ),
+        )
+        fake_api = types.SimpleNamespace(
+            qgis_vector=fake_qgis_vector,
+            error=real_api.error,
+        )
+        monkeypatch.setattr(vector_mod, "api", fake_api)
+
+        vector_id = "test-vec-1"
+        delete_last_updated(vector_id)
+
+        yield types.SimpleNamespace(
+            vector_mod=vector_mod,
+            cache_dir=str(cache_dir),
+            vector_id=vector_id,
+            calls=calls,
+            state=state,
+            store_last_updated=store_last_updated,
+            delete_last_updated=delete_last_updated,
+            real_api=real_api,
+        )
+
+        delete_last_updated(vector_id)
+
+    def _gpkg_column_order(self, cache_file):
+        from qgis.core import QgsVectorLayer
+
+        layer = QgsVectorLayer(cache_file, "tmp", "ogr")
+        names = [n for n in layer.fields().names() if n != "kumoy_id"]
+        del layer
+        return names
+
+    def test_creates_new_cache_when_missing(self, sync_setup):
+        s = sync_setup
+        cache_file = os.path.join(s.cache_dir, f"{s.vector_id}.gpkg")
+        assert not os.path.exists(cache_file)
+
+        s.vector_mod.sync_local_cache(
+            vector_id=s.vector_id,
+            fields=_build_fields(["a", "b"]),
+            geometry_type=QgsWkbTypes.Point,
+        )
+
+        assert os.path.exists(cache_file)
+        assert s.calls["get_features"] >= 1
+        assert s.calls["get_diff"] == 0
+        assert self._gpkg_column_order(cache_file) == ["a", "b"]
+
+    def test_uses_diff_when_order_matches(self, sync_setup):
+        s = sync_setup
+        cache_file = os.path.join(s.cache_dir, f"{s.vector_id}.gpkg")
+        _make_gpkg(cache_file, ["a", "b"])
+        s.store_last_updated(s.vector_id, "2025-01-01T00:00:00Z")
+
+        s.vector_mod.sync_local_cache(
+            vector_id=s.vector_id,
+            fields=_build_fields(["a", "b"]),
+            geometry_type=QgsWkbTypes.Point,
+        )
+
+        assert s.calls["get_diff"] == 1
+        assert s.calls["get_features"] == 0
+        assert self._gpkg_column_order(cache_file) == ["a", "b"]
+
+    def test_recreates_when_order_differs(self, sync_setup):
+        s = sync_setup
+        cache_file = os.path.join(s.cache_dir, f"{s.vector_id}.gpkg")
+        _make_gpkg(cache_file, ["b", "a"])
+        s.store_last_updated(s.vector_id, "2025-01-01T00:00:00Z")
+
+        s.vector_mod.sync_local_cache(
+            vector_id=s.vector_id,
+            fields=_build_fields(["a", "b"]),
+            geometry_type=QgsWkbTypes.Point,
+        )
+
+        assert s.calls["get_diff"] == 0
+        assert s.calls["get_features"] >= 1
+        assert self._gpkg_column_order(cache_file) == ["a", "b"]
+
+        from plugin_dir.kumoy.local_cache.settings import get_last_updated
+
+        assert get_last_updated(s.vector_id) is not None
+
+    def test_recreates_on_max_diff_count_exceeded(self, sync_setup):
+        s = sync_setup
+        cache_file = os.path.join(s.cache_dir, f"{s.vector_id}.gpkg")
+        _make_gpkg(cache_file, ["a", "b"])
+        s.store_last_updated(s.vector_id, "2025-01-01T00:00:00Z")
+
+        def raise_max_diff(vector_id, last_updated):
+            raise s.real_api.error.AppError(
+                "Application Error", "MAX_DIFF_COUNT_EXCEEDED"
+            )
+
+        s.state["get_diff"] = raise_max_diff
+
+        s.vector_mod.sync_local_cache(
+            vector_id=s.vector_id,
+            fields=_build_fields(["a", "b"]),
+            geometry_type=QgsWkbTypes.Point,
+        )
+
+        assert s.calls["get_diff"] == 1
+        assert s.calls["get_features"] >= 1
+        assert self._gpkg_column_order(cache_file) == ["a", "b"]


### PR DESCRIPTION
@bordoray 主に以下の観点でのレビュー・テストをお願いします
- 通常の一連の操作が問題なく動作すること
- ローカルサーバーを立てて、vectorColumnsの返却順を一時的に変えたりしても、ロバストに動作することを確認
- Windowsでファイルロックが回避できているか確認

## 概要

サーバーの `get-features` / `get-diff` のカラム順と、ローカルキャッシュ GPKG の物理カラム順が乖離するとフィーチャ属性がズレる。`sync_local_cache` で順序を比較し、不一致なら再生成する。

背景: サーバー側は columns を `created_at` でソートしているが、同値時の順序が不定。サーバー側でも決定論化される予定だが、既存キャッシュは「不定順」で残っているためクライアント側でも整合チェックが必要。

## 変更

- `_columns_match()` 追加 — GPKG の物理カラム順とサーバー fields を比較（`kumoy_id` は FID 扱いなので除外）
- `_recreate_cache()` 追加 — `clear()` + `_create_new_cache()` の共通ヘルパー
- `sync_local_cache()` — 順序チェック → 不一致なら再生成。`MAX_DIFF_COUNT_EXCEEDED` 経路も共通化
- `_update_existing_cache()` — 順序チェック導入で不要になった `addAttribute`/`deleteAttribute` を削除（残すと末尾追加でサーバー順と乖離する温床）
- `tests/test_local_cache_vector.py` 新規 — `_columns_match` の各ケースと `sync_local_cache` の分岐挙動

## テスト

```bash
docker run --rm -v "$(pwd)":/plugin -w /plugin qgis/qgis:3.40 \
  sh -c "pip3 install --break-system-packages pytest pytest-qgis && \
    xvfb-run -s '+extension GLX -screen 0 1024x768x24' python3 -m pytest tests/ -v"
```

105 件全パス（新規 10 件含む）。