### PR TITLE
Handle session expiration with re-login flow

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -28,14 +28,43 @@ QGIS向けクラウドサービス「Kumoy」を利用するためのプラグ�
 ## アーキテクチャ
 
 - `plugin.py` — プラグインエントリポイント（initGui/unload）
-- `kumoy/api/` — APIクライアント。QgsBlockingNetworkRequestベースのHTTP通信、Bearer認証
-- `kumoy/provider/` — QGISデータプロバイダ実装（QgsVectorDataProvider）
-- `kumoy/local_cache/` — ローカルキャッシュ機構
-- `kumoy/auth_manager.py` — OAuth2認証（PKCE、ローカルHTTPサーバ port 9248）
-- `ui/` — PyQt UI（ダイアログ、ブラウザパネル、レイヤーUI）
+- `error_handler.py` — 共通APIエラーハンドラ
+- `kumoy/` — Kumoyドメインロジック（API・キャッシュ・プロバイダ・設定など、UI非依存の中核）
+  - `kumoy/api/` — APIクライアント。QgsBlockingNetworkRequestベースのHTTP通信、Bearer認証
+  - `kumoy/provider/` — QGISデータプロバイダ実装（QgsVectorDataProvider）
+  - `kumoy/local_cache/` — ローカルキャッシュ機構（純粋なファイル操作のみ）
+  - `kumoy/auth_manager.py` — OAuth2認証（PKCE、ローカルHTTPサーバ port 9248）
+  - `kumoy/settings_manager.py` — QSettingsラッパー（session_token等のドメイン状態を保持）
+- `ui/` — PyQt UI（ダイアログ、ブラウザパネル、レイヤーUI、保存ハンドラ等）
 - `processing/` — QGIS Processing アルゴリズム（ベクターアップロード等）
 - `tests/` — pytest ベースのテスト（pytest-qgis使用）
 - `i18n/` — 国際化（英語デフォルト、日本語対応済み）
+
+### 依存方向のルール
+
+import は上位レイヤから下位レイヤへの一方向のみ。下位から上位への import は循環参照や責務逸脱の温床になるので禁止。
+
+許可される向き（上が上位）：
+
+```
+plugin.py
+  ├→ ui/                 （ダイアログ・ブラウザ・レイヤー連携・保存ハンドラ等）
+  ├→ processing/         （Processingアルゴリズム）
+  └→ error_handler.py    （共通エラーハンドラ。UI/processingから呼ぶ）
+       ↓
+       kumoy/            （api, local_cache, provider, sprite, auth_manager,
+                          settings_manager 等のドメインロジック。UI非依存）
+       ↓
+       pyqt_version.py / qgis_version.py （Qt/QGIS互換レイヤー）
+```
+
+具体ルール：
+
+- `kumoy/` 配下から `ui/`・`processing/`・`error_handler.py` を import しない。UI対話やユーザー操作起点のフロー（QMessageBoxを出す、保存ハンドラ、レイヤー変換ダイアログ等）はすべて `ui/` か `processing/` 側に置く。
+- `kumoy/local_cache/` などのドメイン層は純粋なデータ・ファイル操作のみを担い、UI/API連携を伴うオーケストレーションは UI 層に切り出す（例: `ui/project_save_handler.py`）。
+- Kumoyドメインの状態（session_token、選択中のorganization/project、カスタムサーバURL等）は `kumoy/settings_manager.py` に集約。`ui/` や `processing/` から読み書きするのはOK、`kumoy/` 内部からの参照もsibling同士の通常import。
+- `error_handler.py` は `kumoy.settings_manager` と `kumoy.api.error` のみに依存し、`ui/`・`processing/` のどこからでも import 可。
+- レイヤー間で何かを呼びたくなったら、まず依存方向を確認すること。逆向きの import が必要に思えたら設計を見直すサイン。
 
 ## 注意事項
 

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -28,14 +28,14 @@ QGIS向けクラウドサービス「Kumoy」を利用するためのプラグ�
 ## アーキテクチャ
 
 - `plugin.py` — プラグインエントリポイント（initGui/unload）
-- `error_handler.py` — 共通APIエラーハンドラ
 - `kumoy/` — Kumoyドメインロジック（API・キャッシュ・プロバイダ・設定など、UI非依存の中核）
   - `kumoy/api/` — APIクライアント。QgsBlockingNetworkRequestベースのHTTP通信、Bearer認証
   - `kumoy/provider/` — QGISデータプロバイダ実装（QgsVectorDataProvider）
   - `kumoy/local_cache/` — ローカルキャッシュ機構（純粋なファイル操作のみ）
   - `kumoy/auth_manager.py` — OAuth2認証（PKCE、ローカルHTTPサーバ port 9248）
   - `kumoy/settings_manager.py` — QSettingsラッパー（session_token等のドメイン状態を保持）
-- `ui/` — PyQt UI（ダイアログ、ブラウザパネル、レイヤーUI、保存ハンドラ等）
+- `ui/` — PyQt UI（ダイアログ、ブラウザパネル、レイヤーUI、保存ハンドラ、共通エラーハンドラ等）
+  - `ui/error_handler.py` — 共通APIエラーハンドラ（QMessageBox表示・Browserリフレッシュを含むのでUI責務）
 - `processing/` — QGIS Processing アルゴリズム（ベクターアップロード等）
 - `tests/` — pytest ベースのテスト（pytest-qgis使用）
 - `i18n/` — 国際化（英語デフォルト、日本語対応済み）
@@ -48,22 +48,22 @@ import は上位レイヤから下位レイヤへの一方向のみ。下位か�
 
 ```
 plugin.py
-  ├→ ui/                 （ダイアログ・ブラウザ・レイヤー連携・保存ハンドラ等）
-  ├→ processing/         （Processingアルゴリズム）
-  └→ error_handler.py    （共通エラーハンドラ。UI/processingから呼ぶ）
+  ├→ ui/                  （ダイアログ・ブラウザ・レイヤー連携・保存ハンドラ・error_handler）
+  └→ processing/          （Processingアルゴリズム。ui/error_handler を sideways で利用してOK）
        ↓
-       kumoy/            （api, local_cache, provider, sprite, auth_manager,
-                          settings_manager 等のドメインロジック。UI非依存）
+       kumoy/             （api, local_cache, provider, sprite, auth_manager,
+                           settings_manager 等のドメインロジック。UI非依存）
        ↓
        pyqt_version.py / qgis_version.py （Qt/QGIS互換レイヤー）
 ```
 
 具体ルール：
 
-- `kumoy/` 配下から `ui/`・`processing/`・`error_handler.py` を import しない。UI対話やユーザー操作起点のフロー（QMessageBoxを出す、保存ハンドラ、レイヤー変換ダイアログ等）はすべて `ui/` か `processing/` 側に置く。
+- `kumoy/` 配下から `ui/`・`processing/` を import しない。UI対話やユーザー操作起点のフロー（QMessageBoxを出す、保存ハンドラ、レイヤー変換ダイアログ等）はすべて `ui/` か `processing/` 側に置く。
 - `kumoy/local_cache/` などのドメイン層は純粋なデータ・ファイル操作のみを担い、UI/API連携を伴うオーケストレーションは UI 層に切り出す（例: `ui/project_save_handler.py`）。
 - Kumoyドメインの状態（session_token、選択中のorganization/project、カスタムサーバURL等）は `kumoy/settings_manager.py` に集約。`ui/` や `processing/` から読み書きするのはOK、`kumoy/` 内部からの参照もsibling同士の通常import。
-- `error_handler.py` は `kumoy.settings_manager` と `kumoy.api.error` のみに依存し、`ui/`・`processing/` のどこからでも import 可。
+- `ui/error_handler.py` は `kumoy.settings_manager` と `kumoy.api.error` のみに依存し、QGISの公開API（`dataItemProviderRegistry`）を介してBrowserをリフレッシュする。`plugin.py` への callback 登録などの「隠れた逆向き依存」は持たない。
+- `processing/` → `ui/error_handler` は横方向の例外依存。`error_handler` はUI責務（QMessageBox表示）を持つため `ui/` 配下に置く一方、`processing/` からも共通利用したいので許可。それ以外の `processing/` ↔ `ui/` の横断 import は避ける。
 - レイヤー間で何かを呼びたくなったら、まず依存方向を確認すること。逆向きの import が必要に思えたら設計を見直すサイン。
 
 ## 注意事項

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -72,6 +72,29 @@ plugin.py
 - 外部パッケージ依存なし（ランタイムはQGIS/PyQt/標準ライブラリのみ）
 - UIテキストは `tr()` で翻訳対応すること
 
+### 翻訳ヘルパーの書き方
+
+Qt の翻訳は「コンテキスト名」と「メッセージ」のペアで lookup される。コンテキスト名を間違えると翻訳が引かれず原文のまま表示されるので注意。
+
+- **QObject サブクラス内（QDialog, QgsDataItem 等）**: クラスのメンバ `self.tr()` をそのまま使ってよい。コンテキストにはクラス名が自動で入る。`.ts` ファイル側もクラス名で揃える。
+  ```python
+  class MyDialog(QDialog):
+      def tr(self, message):
+          return QCoreApplication.translate("MyDialog", message)
+  ```
+
+- **モジュールレベル関数や非 QObject のクラス内**: `QCoreApplication.translate("@default", message)` を使う。`"@default"` は Qt が用意している共有コンテキスト。クラス名を勝手に入れると、その名前のクラスが存在しないため翻訳が引かれない。
+  ```python
+  # 良い例（error_handler.py, ui/browser/styledmap.py, kumoy/local_cache/map.py など）
+  def tr(message: str, context: str = "@default") -> str:
+      return QCoreApplication.translate(context, message)
+
+  # 悪い例: クラス名でないコンテキストを勝手に作る
+  def _tr(message): return QCoreApplication.translate("KumoyErrorHandler", message)
+  ```
+
+- 新規ファイル/関数を追加するときは既存の `tr()` ヘルパーの書き方に揃える。`grep` で `QCoreApplication.translate` を確認して、QObject 側はクラス名、非 QObject 側は `"@default"` という分け方になっているかを確認すること。
+
 ## Git ワークフロー
 
 - mainブランチへPR。CI（lint + test）が必須

--- a/error_handler.py
+++ b/error_handler.py
@@ -1,0 +1,68 @@
+"""共通のAPIエラーハンドラ。
+
+UI層の `except Exception` ブロックから呼び出して、
+- セッション切れ（UnauthorizedError）の場合はトークンを破棄して再ログインを促す
+- それ以外は従来どおりエラーメッセージを表示する
+を一箇所で行う。
+"""
+
+from typing import Optional
+
+from qgis.core import Qgis, QgsMessageLog
+from qgis.PyQt.QtCore import QCoreApplication
+from qgis.PyQt.QtWidgets import QMessageBox, QWidget
+
+from .kumoy import constants
+from .kumoy.api.error import UnauthorizedError, format_api_error
+from .kumoy.settings_manager import store_setting
+
+
+def _tr(message: str) -> str:
+    return QCoreApplication.translate("KumoyErrorHandler", message)
+
+
+def _clear_session() -> None:
+    """セッション関連設定のうち、トークン情報のみクリアする。
+
+    selected_organization_id / selected_project_id は残し、
+    再ログイン後にユーザーがプロジェクトを選び直さなくて済むようにする。
+    """
+    store_setting("session_token", "")
+    store_setting("user_info", "")
+
+
+def handle_api_error(
+    exception: Exception,
+    parent: Optional[QWidget] = None,
+    log_prefix: str = "",
+) -> bool:
+    """API例外を共通ハンドリングして表示する。
+
+    Args:
+        exception: 捕捉した例外
+        parent: ダイアログの親ウィジェット
+        log_prefix: ログ・ダイアログのタイトル/接頭辞として使う文字列
+
+    Returns:
+        UnauthorizedError として処理した場合は True、それ以外は False
+    """
+    if isinstance(exception, UnauthorizedError):
+        _clear_session()
+        log_message = _tr("Session expired. Cleared local session token.")
+        QgsMessageLog.logMessage(log_message, constants.LOG_CATEGORY, Qgis.Warning)
+        QMessageBox.warning(
+            parent,
+            _tr("Session expired"),
+            _tr(
+                "Your Kumoy session has expired or is no longer valid.\n"
+                "Please log in again from the Kumoy item in the Browser panel."
+            ),
+        )
+        return True
+
+    detail = format_api_error(exception)
+    title = log_prefix or _tr("Error")
+    log_message = f"{title}: {detail}" if log_prefix else detail
+    QgsMessageLog.logMessage(log_message, constants.LOG_CATEGORY, Qgis.Warning)
+    QMessageBox.critical(parent, title, detail)
+    return False

--- a/error_handler.py
+++ b/error_handler.py
@@ -14,7 +14,7 @@ from qgis.PyQt.QtWidgets import QMessageBox, QWidget
 
 from .kumoy import constants
 from .kumoy.api.error import UnauthorizedError, format_api_error
-from .kumoy.settings_manager import store_setting
+from .kumoy.settings_manager import get_settings, store_setting
 
 
 def _tr(message: str) -> str:
@@ -38,26 +38,31 @@ def handle_api_error(
 ) -> bool:
     """API例外を共通ハンドリングして表示する。
 
-    Args:
-        exception: 捕捉した例外
-        parent: ダイアログの親ウィジェット
-        log_prefix: ログ・ダイアログのタイトル/接頭辞として使う文字列
+    UnauthorizedError の場合はトークンをクリアし、ユーザーへの通知ダイアログは
+    「最初の1回だけ」表示する（QGIS Browser の createChildren など、同一の
+    セッション切れ事象で連続的に呼ばれるパスでもダイアログが多重表示されない
+    ようにするため）。トークンが再ログインで設定されると判定がリセットされる。
 
     Returns:
         UnauthorizedError として処理した場合は True、それ以外は False
     """
     if isinstance(exception, UnauthorizedError):
+        already_cleared = not get_settings().session_token
         _clear_session()
-        log_message = _tr("Session expired. Cleared local session token.")
-        QgsMessageLog.logMessage(log_message, constants.LOG_CATEGORY, Qgis.Warning)
-        QMessageBox.warning(
-            parent,
-            _tr("Session expired"),
-            _tr(
-                "Your Kumoy session has expired or is no longer valid.\n"
-                "Please log in again from the Kumoy item in the Browser panel."
-            ),
+        QgsMessageLog.logMessage(
+            _tr("Session expired. Cleared local session token."),
+            constants.LOG_CATEGORY,
+            Qgis.Warning,
         )
+        if not already_cleared:
+            QMessageBox.warning(
+                parent,
+                _tr("Session expired"),
+                _tr(
+                    "Your Kumoy session has expired or is no longer valid.\n"
+                    "Please log in again from the Kumoy item in the Browser panel."
+                ),
+            )
         return True
 
     detail = format_api_error(exception)

--- a/error_handler.py
+++ b/error_handler.py
@@ -6,7 +6,7 @@ UI層の `except Exception` ブロックから呼び出して、
 を一箇所で行う。
 """
 
-from typing import Optional
+from typing import Callable, List, Optional
 
 from qgis.core import Qgis, QgsMessageLog
 from qgis.PyQt.QtCore import QCoreApplication
@@ -14,11 +14,28 @@ from qgis.PyQt.QtWidgets import QMessageBox, QWidget
 
 from .kumoy import constants
 from .kumoy.api.error import UnauthorizedError, format_api_error
-from .kumoy.settings_manager import get_settings, store_setting
+from .kumoy.settings_manager import store_setting
 
 
 def _tr(message: str) -> str:
-    return QCoreApplication.translate("KumoyErrorHandler", message)
+    return QCoreApplication.translate("@default", message)
+
+
+# セッション切れを検知した際に呼ばれるコールバック群。
+# 主に Browser パネルの再構築（古い Item を消す）に使う想定。
+# error_handler はここに何も登録せず、上位の plugin.py 側が initGui で
+# 登録、unload で解除する。
+_session_cleared_callbacks: List[Callable[[], None]] = []
+
+
+def register_session_cleared_callback(fn: Callable[[], None]) -> None:
+    if fn not in _session_cleared_callbacks:
+        _session_cleared_callbacks.append(fn)
+
+
+def unregister_session_cleared_callback(fn: Callable[[], None]) -> None:
+    if fn in _session_cleared_callbacks:
+        _session_cleared_callbacks.remove(fn)
 
 
 def _clear_session() -> None:
@@ -31,6 +48,18 @@ def _clear_session() -> None:
     store_setting("user_info", "")
 
 
+def _notify_session_cleared() -> None:
+    for cb in list(_session_cleared_callbacks):
+        try:
+            cb()
+        except Exception as e:
+            QgsMessageLog.logMessage(
+                f"session-cleared callback failed: {e}",
+                constants.LOG_CATEGORY,
+                Qgis.Warning,
+            )
+
+
 def handle_api_error(
     exception: Exception,
     parent: Optional[QWidget] = None,
@@ -38,31 +67,28 @@ def handle_api_error(
 ) -> bool:
     """API例外を共通ハンドリングして表示する。
 
-    UnauthorizedError の場合はトークンをクリアし、ユーザーへの通知ダイアログは
-    「最初の1回だけ」表示する（QGIS Browser の createChildren など、同一の
-    セッション切れ事象で連続的に呼ばれるパスでもダイアログが多重表示されない
-    ようにするため）。トークンが再ログインで設定されると判定がリセットされる。
+    UnauthorizedError の場合はトークンをクリアし、再ログインを促すダイアログを
+    表示する。さらに登録済みコールバック（Browser パネル再構築など）を発火する。
 
     Returns:
         UnauthorizedError として処理した場合は True、それ以外は False
     """
     if isinstance(exception, UnauthorizedError):
-        already_cleared = not get_settings().session_token
         _clear_session()
         QgsMessageLog.logMessage(
             _tr("Session expired. Cleared local session token."),
             constants.LOG_CATEGORY,
             Qgis.Warning,
         )
-        if not already_cleared:
-            QMessageBox.warning(
-                parent,
-                _tr("Session expired"),
-                _tr(
-                    "Your Kumoy session has expired or is no longer valid.\n"
-                    "Please log in again from the Kumoy item in the Browser panel."
-                ),
-            )
+        QMessageBox.warning(
+            parent,
+            _tr("Session expired"),
+            _tr(
+                "Your Kumoy session has expired or is no longer valid.\n"
+                "Please log in again from the Kumoy item in the Browser panel."
+            ),
+        )
+        _notify_session_cleared()
         return True
 
     detail = format_api_error(exception)

--- a/error_handler.py
+++ b/error_handler.py
@@ -14,7 +14,7 @@ from qgis.PyQt.QtWidgets import QMessageBox, QWidget
 
 from .kumoy import constants
 from .kumoy.api.error import UnauthorizedError, format_api_error
-from .kumoy.settings_manager import get_settings, store_setting
+from .kumoy.settings_manager import store_setting
 
 
 def _tr(message: str) -> str:
@@ -67,38 +67,28 @@ def handle_api_error(
 ) -> bool:
     """API例外を共通ハンドリングして表示する。
 
-    UnauthorizedError の場合はトークンをクリアし、再ログインを促すダイアログと
-    登録済みコールバック（Browser パネル再構築など）を発火する。ただし「トークン
-    がまだ有効と認識されていた」最初の1回だけ通知し、すでにクリア済みの状態で
-    再度 UnauthorizedError が来た場合は黙ってログだけ残す。
-
-    これは QGIS Browser がツリー展開時に複数の createChildren を連鎖的に発火
-    （RootCollection → VectorRoot → StyledMapRoot 等）するため、最初の API
-    呼び出しで 401 を受けた直後に同じ事象でモーダル多重表示・再構築多重実行が
-    起きるのを防ぐためのデバウンス。再ログインで session_token が再設定される
-    と判定がリセットされる。
+    UnauthorizedError の場合はトークンをクリアし、再ログインを促すダイアログを
+    表示する。さらに登録済みコールバック（Browser パネル再構築など）を発火する。
 
     Returns:
         UnauthorizedError として処理した場合は True、それ以外は False
     """
     if isinstance(exception, UnauthorizedError):
-        already_cleared = not get_settings().session_token
         _clear_session()
         QgsMessageLog.logMessage(
             _tr("Session expired. Cleared local session token."),
             constants.LOG_CATEGORY,
             Qgis.Warning,
         )
-        if not already_cleared:
-            QMessageBox.warning(
-                parent,
-                _tr("Session expired"),
-                _tr(
-                    "Your Kumoy session has expired or is no longer valid.\n"
-                    "Please log in again from the Kumoy item in the Browser panel."
-                ),
-            )
-            _notify_session_cleared()
+        QMessageBox.warning(
+            parent,
+            _tr("Session expired"),
+            _tr(
+                "Your Kumoy session has expired or is no longer valid.\n"
+                "Please log in again from the Kumoy item in the Browser panel."
+            ),
+        )
+        _notify_session_cleared()
         return True
 
     detail = format_api_error(exception)

--- a/error_handler.py
+++ b/error_handler.py
@@ -14,7 +14,7 @@ from qgis.PyQt.QtWidgets import QMessageBox, QWidget
 
 from .kumoy import constants
 from .kumoy.api.error import UnauthorizedError, format_api_error
-from .kumoy.settings_manager import store_setting
+from .kumoy.settings_manager import get_settings, store_setting
 
 
 def _tr(message: str) -> str:
@@ -67,28 +67,38 @@ def handle_api_error(
 ) -> bool:
     """API例外を共通ハンドリングして表示する。
 
-    UnauthorizedError の場合はトークンをクリアし、再ログインを促すダイアログを
-    表示する。さらに登録済みコールバック（Browser パネル再構築など）を発火する。
+    UnauthorizedError の場合はトークンをクリアし、再ログインを促すダイアログと
+    登録済みコールバック（Browser パネル再構築など）を発火する。ただし「トークン
+    がまだ有効と認識されていた」最初の1回だけ通知し、すでにクリア済みの状態で
+    再度 UnauthorizedError が来た場合は黙ってログだけ残す。
+
+    これは QGIS Browser がツリー展開時に複数の createChildren を連鎖的に発火
+    （RootCollection → VectorRoot → StyledMapRoot 等）するため、最初の API
+    呼び出しで 401 を受けた直後に同じ事象でモーダル多重表示・再構築多重実行が
+    起きるのを防ぐためのデバウンス。再ログインで session_token が再設定される
+    と判定がリセットされる。
 
     Returns:
         UnauthorizedError として処理した場合は True、それ以外は False
     """
     if isinstance(exception, UnauthorizedError):
+        already_cleared = not get_settings().session_token
         _clear_session()
         QgsMessageLog.logMessage(
             _tr("Session expired. Cleared local session token."),
             constants.LOG_CATEGORY,
             Qgis.Warning,
         )
-        QMessageBox.warning(
-            parent,
-            _tr("Session expired"),
-            _tr(
-                "Your Kumoy session has expired or is no longer valid.\n"
-                "Please log in again from the Kumoy item in the Browser panel."
-            ),
-        )
-        _notify_session_cleared()
+        if not already_cleared:
+            QMessageBox.warning(
+                parent,
+                _tr("Session expired"),
+                _tr(
+                    "Your Kumoy session has expired or is no longer valid.\n"
+                    "Please log in again from the Kumoy item in the Browser panel."
+                ),
+            )
+            _notify_session_cleared()
         return True
 
     detail = format_api_error(exception)

--- a/error_handler.py
+++ b/error_handler.py
@@ -9,12 +9,12 @@ UI層の `except Exception` ブロックから呼び出して、
 from typing import Callable, List, Optional
 
 from qgis.core import Qgis, QgsMessageLog
-from qgis.PyQt.QtCore import QCoreApplication
+from qgis.PyQt.QtCore import QCoreApplication, QTimer
 from qgis.PyQt.QtWidgets import QMessageBox, QWidget
 
 from .kumoy import constants
 from .kumoy.api.error import UnauthorizedError, format_api_error
-from .kumoy.settings_manager import store_setting
+from .kumoy.settings_manager import get_settings, store_setting
 
 
 def _tr(message: str) -> str:
@@ -60,6 +60,20 @@ def _notify_session_cleared() -> None:
             )
 
 
+def _show_session_expired_and_notify() -> None:
+    """セッション切れダイアログを表示し、登録済みコールバックを発火する。
+    QTimer.singleShot 経由でメインイベントループの次の tick に呼ばれる前提。"""
+    QMessageBox.warning(
+        None,
+        _tr("Session expired"),
+        _tr(
+            "Your Kumoy session has expired or is no longer valid.\n"
+            "Please log in again from the Kumoy item in the Browser panel."
+        ),
+    )
+    _notify_session_cleared()
+
+
 def handle_api_error(
     exception: Exception,
     parent: Optional[QWidget] = None,
@@ -67,28 +81,30 @@ def handle_api_error(
 ) -> bool:
     """API例外を共通ハンドリングして表示する。
 
-    UnauthorizedError の場合はトークンをクリアし、再ログインを促すダイアログを
-    表示する。さらに登録済みコールバック（Browser パネル再構築など）を発火する。
+    UnauthorizedError の場合はトークンをクリアした上で、ダイアログ表示と
+    コールバック発火 (Browser パネル再構築) を **次のイベントループ tick に
+    遅延させる**。これは QGIS の `createChildren` のような Python オブジェクトの
+    寿命を巻き込むコンテキストから呼ばれたときに、Browser model から item を
+    取り除く操作が同期実行されてクラッシュするのを防ぐため。
+
+    また、複数の `createChildren` が並行発火して 401 が連発する状況でも
+    モーダルが多重キューイングされないよう、トークンが「直前まで有効」だった
+    最初の1回だけ通知する（dedup）。再ログインで token が再設定されると判定は
+    リセットされる。
 
     Returns:
         UnauthorizedError として処理した場合は True、それ以外は False
     """
     if isinstance(exception, UnauthorizedError):
+        already_cleared = not get_settings().session_token
         _clear_session()
         QgsMessageLog.logMessage(
             _tr("Session expired. Cleared local session token."),
             constants.LOG_CATEGORY,
             Qgis.Warning,
         )
-        QMessageBox.warning(
-            parent,
-            _tr("Session expired"),
-            _tr(
-                "Your Kumoy session has expired or is no longer valid.\n"
-                "Please log in again from the Kumoy item in the Browser panel."
-            ),
-        )
-        _notify_session_cleared()
+        if not already_cleared:
+            QTimer.singleShot(0, _show_session_expired_and_notify)
         return True
 
     detail = format_api_error(exception)

--- a/kumoy/api/client.py
+++ b/kumoy/api/client.py
@@ -5,7 +5,7 @@ from qgis.core import QgsBlockingNetworkRequest
 from qgis.PyQt.QtCore import QByteArray, QUrl
 from qgis.PyQt.QtNetwork import QNetworkRequest
 
-from ...pyqt_version import Q_NETWORK_REQUEST_HEADER
+from ...pyqt_version import Q_NETWORK_REQUEST_ATTRIBUTE, Q_NETWORK_REQUEST_HEADER
 from ..get_token import get_token
 from . import config as api_config
 from . import error as api_error
@@ -22,176 +22,97 @@ def handle_blocking_reply(content: QByteArray) -> Any:
     return json.loads(text)
 
 
+def _build_request(url: str) -> QNetworkRequest:
+    """Build an authorized QNetworkRequest. Raises UnauthorizedError if no token."""
+    token = get_token()
+    if not token:
+        raise api_error.UnauthorizedError("Unauthorized", "No session token")
+
+    req = QNetworkRequest(QUrl(url))
+    req.setRawHeader(
+        "Authorization".encode("utf-8"),
+        f"Bearer {token}".encode("utf-8"),
+    )
+    return req
+
+
+def _process_response(blocking_request: QgsBlockingNetworkRequest, err: int) -> Any:
+    """Inspect the reply, raise typed errors on failure, otherwise return content."""
+    reply = blocking_request.reply()
+    status_code = reply.attribute(Q_NETWORK_REQUEST_ATTRIBUTE.HttpStatusCodeAttribute)
+    content = handle_blocking_reply(reply.content())
+
+    if status_code in (401, 403):
+        message = "Unauthorized"
+        detail = ""
+        if isinstance(content, dict):
+            detail = content.get("error", "") or content.get("message", "")
+        raise api_error.UnauthorizedError(message, detail)
+
+    if err != QgsBlockingNetworkRequest.NoError:
+        if not content:
+            error_message = blocking_request.errorMessage()
+            api_error.raise_error({"message": error_message, "error": ""})
+        else:
+            api_error.raise_error(content)
+
+    return content
+
+
 class ApiClient:
     """Base API client for Kumoy backend"""
 
     @staticmethod
     def get(endpoint: str, params: Optional[Dict] = None) -> Any:
-        """
-        Args:
-            endpoint (str): _description_
-            params (Optional[Dict], optional): _description_. Defaults to None.
-
-        Returns:
-            dict: {"content": dict, "error": None} or {"content": None, "error": str}
-        """
         _api_config = api_config.get_api_config()
-        # Build URL with query parameters if provided
         url = f"{_api_config.SERVER_URL}/api{endpoint}"
         if params:
-            query_items = []
-            for key, value in params.items():
-                query_items.append(f"{key}={value}")
+            query_items = [f"{key}={value}" for key, value in params.items()]
             url = f"{url}?{'&'.join(query_items)}"
 
-        # Create request with authorization header
-        req = QNetworkRequest(QUrl(url))
-        token = get_token()
+        req = _build_request(url)
 
-        if not token:
-            return {"content": None, "error": "Authentication Error"}
-
-        req.setRawHeader(
-            "Authorization".encode("utf-8"),
-            f"Bearer {token}".encode("utf-8"),
-        )
-
-        # Execute request
         blocking_request = QgsBlockingNetworkRequest()
         err = blocking_request.get(req, forceRefresh=True)
-        content = handle_blocking_reply(blocking_request.reply().content())
-        if err != QgsBlockingNetworkRequest.NoError:
-            # Handle empty content when network error occurs
-            if not content:
-                error_message = blocking_request.errorMessage()
-                api_error.raise_error({"message": error_message, "error": ""})
-            else:
-                api_error.raise_error(content)
-
-        return content
+        return _process_response(blocking_request, err)
 
     @staticmethod
     def post(endpoint: str, data: Any) -> Any:
-        """Make POST request to API endpoint
-
-        Args:
-            endpoint (str): API endpoint
-            data (Any): Data to send in the request body
-
-        Returns:
-            dict: {"content": dict, "error": None} or {"content": None, "error": str}
-        """
         _api_config = api_config.get_api_config()
         url = f"{_api_config.SERVER_URL}/api{endpoint}"
 
-        # Create request with authorization header
-        req = QNetworkRequest(QUrl(url))
-        token = get_token()
-
-        if not token:
-            return {"content": None, "error": "Authentication Error"}
-
-        req.setRawHeader(
-            "Authorization".encode("utf-8"),
-            f"Bearer {token}".encode("utf-8"),
-        )
+        req = _build_request(url)
         req.setHeader(Q_NETWORK_REQUEST_HEADER.ContentTypeHeader, "application/json")
 
-        # Use json.dumps to preserve dictionary order
         json_data = json.dumps(data, ensure_ascii=False)
         byte_array = QByteArray(json_data.encode("utf-8"))
 
-        # Execute request
         blocking_request = QgsBlockingNetworkRequest()
         err = blocking_request.post(req, byte_array)
-        content = handle_blocking_reply(blocking_request.reply().content())
-        if err != QgsBlockingNetworkRequest.NoError:
-            if not content:
-                error_message = blocking_request.errorMessage()
-                api_error.raise_error({"message": error_message, "error": ""})
-            else:
-                api_error.raise_error(content)
-
-        return content
+        return _process_response(blocking_request, err)
 
     @staticmethod
     def put(endpoint: str, data: Any) -> Any:
-        """Make PUT request to API endpoint
-
-        Args:
-            endpoint (str): API endpoint
-            data (Any): Data to send in the request body
-
-        Returns:
-            dict: {"content": dict, "error": None} or {"content": None, "error": str}
-        """
         _api_config = api_config.get_api_config()
         url = f"{_api_config.SERVER_URL}/api{endpoint}"
 
-        # Create request with authorization header
-        req = QNetworkRequest(QUrl(url))
-        token = get_token()
-
-        if not token:
-            return {"content": None, "error": "Authentication Error"}
-
-        req.setRawHeader(
-            "Authorization".encode("utf-8"),
-            f"Bearer {token}".encode("utf-8"),
-        )
+        req = _build_request(url)
         req.setHeader(Q_NETWORK_REQUEST_HEADER.ContentTypeHeader, "application/json")
 
-        # Use json.dumps to preserve dictionary order
         json_data = json.dumps(data, ensure_ascii=False)
         byte_array = QByteArray(json_data.encode("utf-8"))
 
-        # Execute request
         blocking_request = QgsBlockingNetworkRequest()
         err = blocking_request.put(req, byte_array)
-        content = handle_blocking_reply(blocking_request.reply().content())
-        if err != QgsBlockingNetworkRequest.NoError:
-            if not content:
-                error_message = blocking_request.errorMessage()
-                api_error.raise_error({"message": error_message, "error": ""})
-            else:
-                api_error.raise_error(content)
-
-        return content
+        return _process_response(blocking_request, err)
 
     @staticmethod
     def delete(endpoint: str) -> Any:
-        """Make DELETE request to API endpoint
-
-        Args:
-            endpoint (str): API endpoint
-
-        Returns:
-            dict: {"content": dict, "error": None} or {"content": None, "error": str}
-        """
         _api_config = api_config.get_api_config()
         url = f"{_api_config.SERVER_URL}/api{endpoint}"
 
-        # Create request with authorization header
-        req = QNetworkRequest(QUrl(url))
-        token = get_token()
+        req = _build_request(url)
 
-        if not token:
-            return {"content": None, "error": "Authentication Error"}
-
-        req.setRawHeader(
-            "Authorization".encode("utf-8"),
-            f"Bearer {token}".encode("utf-8"),
-        )
-
-        # Execute request
         blocking_request = QgsBlockingNetworkRequest()
         err = blocking_request.deleteResource(req)
-        content = handle_blocking_reply(blocking_request.reply().content())
-        if err != QgsBlockingNetworkRequest.NoError:
-            if not content:
-                error_message = blocking_request.errorMessage()
-                api_error.raise_error({"message": error_message})
-            else:
-                api_error.raise_error(content)
-
-        return content
+        return _process_response(blocking_request, err)

--- a/kumoy/api/config.py
+++ b/kumoy/api/config.py
@@ -1,7 +1,7 @@
 from abc import ABC
 from dataclasses import dataclass
 
-from ...settings_manager import get_settings
+from ..settings_manager import get_settings
 
 # テスト環境
 DEFAULT_SERVER_URL: str = "https://app.kumoy.io"

--- a/kumoy/get_token.py
+++ b/kumoy/get_token.py
@@ -1,6 +1,6 @@
 from typing import Optional
 
-from ..settings_manager import get_settings
+from .settings_manager import get_settings
 
 
 def get_token() -> Optional[str]:

--- a/kumoy/local_cache/map.py
+++ b/kumoy/local_cache/map.py
@@ -2,56 +2,18 @@ import os
 
 from qgis.core import Qgis, QgsApplication, QgsMessageLog, QgsProject
 from qgis.PyQt.QtCore import QCoreApplication
-from qgis.PyQt.QtWidgets import QMessageBox
-from qgis.utils import iface
 
-from ... import settings_manager
-from ...pyqt_version import Q_MESSAGEBOX_STD_BUTTON
-from ...ui.layers.convert_vector import (
-    convert_local_layers,
-)
-from .. import api
-from ..api.error import format_api_error
 from ..constants import LOG_CATEGORY
-from ..sprite import generate_sprite, pin_fixed_aspect_ratios, upload_sprites
+from ..sprite import pin_fixed_aspect_ratios
 
-# Flag to prevent double updates when handling project saved event
+# Flag to prevent double updates when handling project saved event.
+# write_qgsfile() で QGIS プロジェクトをディスクに書き出す際、
+# QgsProject.projectSaved シグナル経由で再入することを防ぐためのフラグ。
 is_updating = False
 
 
 def tr(message: str, context: str = "@default") -> str:
     return QCoreApplication.translate(context, message)
-
-
-def show_map_save_result(
-    map_name: str,
-    conversion_errors: list[tuple[str, str]],
-) -> None:
-    """Show success or warning message after map save operation.
-
-    Args:
-        map_name: Name of the map
-        conversion_errors: List of (layer_name, error_message) tuples
-    """
-    if conversion_errors:
-        error_details = "\n".join(
-            [f"• {layer_name}\n{error}\n" for layer_name, error in conversion_errors]
-        )
-        # Limit error details length
-        msg_max_length = 1000
-        if len(error_details) > msg_max_length:
-            error_details = error_details[:msg_max_length] + "..."
-
-        report_msg = tr(
-            "Map '{}' has been saved successfully.\n\n"
-            "Warning: {} layers could not be converted:\n\n{}"
-        ).format(map_name, len(conversion_errors), error_details)
-
-        QMessageBox.warning(None, tr("Map Saved with Warnings"), report_msg)
-    else:
-        # No conversion errors means also no local layers to convert
-        report_msg = tr("Map '{}' has been saved successfully.").format(map_name)
-        iface.messageBar().pushSuccess(tr("Success"), report_msg)
 
 
 def _get_cache_dir() -> str:
@@ -177,130 +139,3 @@ def _get_qgs_str(map_path: str) -> str:
         raise Exception(err)
 
     return qgs_str
-
-
-def handle_project_saved() -> None:
-    """Update current project to Kumoy when QGIS project is saved"""
-    # Do not proceed if already updating from styled map item
-    if is_updating:
-        return
-
-    project = QgsProject.instance()
-
-    # Get styled map ID from custom variables
-    custom_vars = project.customVariables()
-    styled_map_id = custom_vars.get("kumoy_map_id")
-
-    # Case of non kumoy map
-    if not styled_map_id:
-        return
-
-    # Check if project file is saved in local cache
-    file_path = os.path.abspath(project.absoluteFilePath())
-    local_cache_dir = os.path.abspath(_get_cache_dir())
-
-    try:
-        in_cache = os.path.commonpath([file_path, local_cache_dir]) == local_cache_dir
-    except ValueError:
-        in_cache = False
-
-    # Clear custom variables and don't proceed if the project file not saved in local cache
-    if not in_cache:
-        QgsProject.instance().setCustomVariables({})
-        return
-
-    # Get and validate map belongs to current project
-    try:
-        styled_map_detail = api.styledmap.get_styled_map(styled_map_id)
-        settings = settings_manager.get_settings()
-
-        if settings.selected_project_id != styled_map_detail.projectId:
-            QMessageBox.critical(
-                None,
-                tr("Wrong Project"),
-                tr(
-                    "This map belongs to a different Kumoy project. "
-                    "Please switch to the correct project."
-                ),
-            )
-            return
-    except Exception as e:
-        error_text = format_api_error(e)
-        QgsMessageLog.logMessage(
-            tr("Error loading map: {}").format(error_text),
-            LOG_CATEGORY,
-            Qgis.Critical,
-        )
-        QMessageBox.critical(
-            None,
-            tr("Error"),
-            tr("Error loading map: {}").format(error_text),
-        )
-        return
-
-    # don't process if role cannot edit
-    if styled_map_detail.role not in ["ADMIN", "OWNER"]:
-        iface.messageBar().pushMessage(
-            tr("Failed"),
-            tr("You do not have permission to save this map to Kumoy."),
-        )
-        return
-
-    # Check dialog
-    confirm = QMessageBox.question(
-        None,
-        tr("Save Map"),
-        tr(
-            "Are you sure you want to overwrite the map '{}' with the current project state?"
-        ).format(styled_map_detail.name),
-        Q_MESSAGEBOX_STD_BUTTON.Yes | Q_MESSAGEBOX_STD_BUTTON.No,
-        Q_MESSAGEBOX_STD_BUTTON.No,
-    )
-    if confirm != Q_MESSAGEBOX_STD_BUTTON.Yes:
-        return
-
-    # Convert local layers to Kumoy layers if any
-    cancelled, conversion_errors = convert_local_layers(styled_map_detail.projectId)
-    if cancelled:
-        return
-
-    try:
-        # Save project with converted layers
-        qgsproject_str = write_qgsfile(styled_map_id)
-
-        # Generate sprites and upload if changed
-        sprite_data = generate_sprite(project)
-        new_assets_hash = sprite_data.assets_hash if sprite_data else None
-
-        update_options = api.styledmap.UpdateStyledMapOptions(
-            qgisproject=qgsproject_str,
-        )
-        if new_assets_hash != styled_map_detail.assetsHash:
-            if sprite_data is not None:
-                upload_sprites(styled_map_id, sprite_data)
-            # memo: new_assets_hashがNoneならnullをセットする
-            update_options.assetsHash = new_assets_hash
-        updated_styled_map = api.styledmap.update_styled_map(
-            styled_map_id,
-            update_options,
-        )
-    except Exception as e:
-        error_text = format_api_error(e)
-        QgsMessageLog.logMessage(
-            tr("Error saving map: {}").format(error_text),
-            LOG_CATEGORY,
-            Qgis.Critical,
-        )
-        QMessageBox.critical(
-            None,
-            tr("Error"),
-            tr("Error saving map: {}").format(error_text),
-        )
-        return
-
-    # Update map name if changed by other users
-    QgsProject.instance().setTitle(updated_styled_map.name)
-    QgsProject.instance().setDirty(False)
-
-    # Show success message with conversion errors summary if any
-    show_map_save_result(updated_styled_map.name, conversion_errors)

--- a/kumoy/local_cache/map.py
+++ b/kumoy/local_cache/map.py
@@ -16,7 +16,7 @@ def tr(message: str, context: str = "@default") -> str:
     return QCoreApplication.translate(context, message)
 
 
-def _get_cache_dir() -> str:
+def get_cache_dir() -> str:
     """Return the directory where cache files are stored.
     data_type: subdirectory name maps or vectors"""
     setting_dir = QgsApplication.qgisSettingsDirPath()
@@ -27,7 +27,7 @@ def _get_cache_dir() -> str:
 
 def get_filepath(map_id: str) -> str:
     """Retrieve a cached map path."""
-    cache_dir = _get_cache_dir()
+    cache_dir = get_cache_dir()
     cache_file = os.path.join(cache_dir, f"{map_id}.qgs")
     return cache_file
 
@@ -36,7 +36,7 @@ def clear(map_id: str) -> bool:
     """Clear cache for a specific map.
     Returns True if all files were deleted successfully, False otherwise.
     """
-    cache_dir = _get_cache_dir()
+    cache_dir = get_cache_dir()
     success = True
     # Remove all files containing map_id in their names
     for filename in os.listdir(cache_dir):
@@ -65,7 +65,7 @@ def clear(map_id: str) -> bool:
 def clear_all() -> bool:
     """Clear all cached map files. Returns True if all files were deleted successfully."""
 
-    cache_dir = _get_cache_dir()
+    cache_dir = get_cache_dir()
     success = True
 
     # Remove all files in cache directory

--- a/kumoy/local_cache/map.py
+++ b/kumoy/local_cache/map.py
@@ -17,8 +17,7 @@ def tr(message: str, context: str = "@default") -> str:
 
 
 def get_cache_dir() -> str:
-    """Return the directory where cache files are stored.
-    data_type: subdirectory name maps or vectors"""
+    """Return the directory where map cache files (.qgs) are stored."""
     setting_dir = QgsApplication.qgisSettingsDirPath()
     cache_dir = os.path.join(setting_dir, "kumoygis", "local_cache", "maps")
     os.makedirs(cache_dir, exist_ok=True)

--- a/kumoy/settings_manager.py
+++ b/kumoy/settings_manager.py
@@ -3,8 +3,8 @@ from dataclasses import dataclass
 from qgis.core import Qgis, QgsMessageLog
 from qgis.PyQt.QtCore import QSettings
 
-from .kumoy import constants
-from .kumoy.local_cache.settings import reset_local_cache_settings
+from . import constants
+from .local_cache.settings import reset_local_cache_settings
 
 
 @dataclass

--- a/plugin.py
+++ b/plugin.py
@@ -14,6 +14,7 @@ from qgis.gui import QgisInterface, QgsGui
 from qgis.PyQt.QtCore import QCoreApplication, QTranslator
 from qgis.PyQt.QtWidgets import QAction, QMenu, QMessageBox
 
+from .error_handler import handle_api_error
 from .kumoy import api
 from .kumoy.api.error import AppError, format_api_error
 from .kumoy.constants import (
@@ -22,13 +23,13 @@ from .kumoy.constants import (
     LOG_CATEGORY,
     PLUGIN_NAME,
 )
-from .kumoy.local_cache.map import handle_project_saved
+from .ui.project_save_handler import handle_project_saved
 from .kumoy.provider.dataprovider_metadata import KumoyProviderMetadata
 from .plugin_version import is_plugin_version_compatible, read_plugin_version
 from .processing.close_all_processing_dialogs import close_all_processing_dialogs
 from .processing.provider import KumoyProcessingProvider
 from .pyqt_version import Q_MESSAGEBOX_STD_BUTTON
-from .settings_manager import (
+from .kumoy.settings_manager import (
     get_settings,
     reset_settings,
     store_setting,
@@ -276,17 +277,7 @@ class KumoyPlugin:
                 QgsProject.instance().clear()
                 return
         except Exception as e:
-            error_text = api.error.format_api_error(e)
-            QgsMessageLog.logMessage(
-                self.tr("Error loading map: {}").format(error_text),
-                LOG_CATEGORY,
-                Qgis.Critical,
-            )
-            QMessageBox.critical(
-                None,
-                self.tr("Error"),
-                self.tr("Error loading map: {}").format(error_text),
-            )
+            handle_api_error(e, parent=None, log_prefix=self.tr("Error loading map"))
             QgsProject.instance().clear()
             return
 

--- a/plugin.py
+++ b/plugin.py
@@ -14,7 +14,11 @@ from qgis.gui import QgisInterface, QgsGui
 from qgis.PyQt.QtCore import QCoreApplication, QTranslator
 from qgis.PyQt.QtWidgets import QAction, QMenu, QMessageBox
 
-from .error_handler import handle_api_error
+from .error_handler import (
+    handle_api_error,
+    register_session_cleared_callback,
+    unregister_session_cleared_callback,
+)
 from .kumoy import api
 from .kumoy.api.error import AppError, format_api_error
 from .kumoy.constants import (
@@ -114,11 +118,7 @@ class KumoyPlugin:
             close_all_processing_dialogs()
             reset_settings()
 
-            # Refresh browser panel
-            registry = QgsApplication.instance().dataItemProviderRegistry()
-            registry.removeProvider(self.dip)
-            self.dip = DataItemProvider()
-            registry.addProvider(self.dip)
+            self._refresh_browser_panel()
 
             QMessageBox.information(
                 self.win,
@@ -160,11 +160,7 @@ class KumoyPlugin:
             self.tr("You have been logged out from Kumoy."),
         )
 
-        # Refresh browser panel
-        registry = QgsApplication.instance().dataItemProviderRegistry()
-        registry.removeProvider(self.dip)
-        self.dip = DataItemProvider()
-        registry.addProvider(self.dip)
+        self._refresh_browser_panel()
 
     def show_layer_context_menu(self, menu: QMenu):
         """Add custom action to layer context menu"""
@@ -341,9 +337,20 @@ class KumoyPlugin:
             self.dip = DataItemProvider()
             registry.addProvider(self.dip)
 
+    def _refresh_browser_panel(self):
+        """Kumoy の DataItemProvider を再登録し、ブラウザパネルの子アイテムを
+        強制的に再構築する。ログアウト・セッション切れ時の表示更新に使う。"""
+        registry = QgsApplication.instance().dataItemProviderRegistry()
+        registry.removeProvider(self.dip)
+        self.dip = DataItemProvider()
+        registry.addProvider(self.dip)
+
     def initGui(self):
         self.dip = DataItemProvider()
         QgsApplication.instance().dataItemProviderRegistry().addProvider(self.dip)
+
+        # セッション切れ検知時にブラウザを再構築する
+        register_session_cleared_callback(self._refresh_browser_panel)
 
         self.data_item_gui_provider = KumoyDataItemGuiProvider()
         QgsGui.dataItemGuiProviderRegistry().addProvider(self.data_item_gui_provider)
@@ -416,6 +423,8 @@ class KumoyPlugin:
         # Remove translator
         if self.translator:
             QCoreApplication.removeTranslator(self.translator)
+
+        unregister_session_cleared_callback(self._refresh_browser_panel)
 
         QgsApplication.instance().dataItemProviderRegistry().removeProvider(self.dip)
 

--- a/plugin.py
+++ b/plugin.py
@@ -338,12 +338,16 @@ class KumoyPlugin:
             registry.addProvider(self.dip)
 
     def _refresh_browser_panel(self):
-        """Kumoy の DataItemProvider を再登録し、ブラウザパネルの子アイテムを
-        強制的に再構築する。ログアウト・セッション切れ時の表示更新に使う。"""
-        registry = QgsApplication.instance().dataItemProviderRegistry()
-        registry.removeProvider(self.dip)
-        self.dip = DataItemProvider()
-        registry.addProvider(self.dip)
+        """Kumoy ルートアイテム配下の子要素を再構築する。
+        ログアウト・セッション切れ時の表示更新に使う。
+
+        既存の `RootCollection.refresh()` を呼ぶ方式にしている。これは
+        `depopulate()` を内部で呼ぶため Qt の browser model が変更を
+        検知して描画を更新する。`registry.removeProvider/addProvider` の
+        付け替え方式だと model 側が再描画してくれないことがある。"""
+        if self.dip is None or self.dip.root_collection is None:
+            return
+        self.dip.root_collection.refresh()
 
     def initGui(self):
         self.dip = DataItemProvider()

--- a/plugin.py
+++ b/plugin.py
@@ -14,11 +14,7 @@ from qgis.gui import QgisInterface, QgsGui
 from qgis.PyQt.QtCore import QCoreApplication, QTranslator
 from qgis.PyQt.QtWidgets import QAction, QMenu, QMessageBox
 
-from .error_handler import (
-    handle_api_error,
-    register_session_cleared_callback,
-    unregister_session_cleared_callback,
-)
+from .ui.error_handler import handle_api_error
 from .kumoy import api
 from .kumoy.api.error import AppError, format_api_error
 from .kumoy.constants import (
@@ -338,13 +334,10 @@ class KumoyPlugin:
             registry.addProvider(self.dip)
 
     def _refresh_browser_panel(self):
-        """Kumoy ルートアイテム配下の子要素を再構築する。
-        ログアウト・セッション切れ時の表示更新に使う。
-
-        既存の `RootCollection.refresh()` を呼ぶ方式にしている。これは
-        `depopulate()` を内部で呼ぶため Qt の browser model が変更を
-        検知して描画を更新する。`registry.removeProvider/addProvider` の
-        付け替え方式だと model 側が再描画してくれないことがある。"""
+        """Kumoy ルートアイテム配下の子要素を depopulate して再構築させる。
+        ログアウトやプラグイン設定リセット時の表示更新に使う。
+        （セッション切れ時の自動リフレッシュは `ui/error_handler.py` 側が
+        registry 経由で同じことをする。）"""
         if self.dip is None or self.dip.root_collection is None:
             return
         self.dip.root_collection.refresh()
@@ -352,9 +345,6 @@ class KumoyPlugin:
     def initGui(self):
         self.dip = DataItemProvider()
         QgsApplication.instance().dataItemProviderRegistry().addProvider(self.dip)
-
-        # セッション切れ検知時にブラウザを再構築する
-        register_session_cleared_callback(self._refresh_browser_panel)
 
         self.data_item_gui_provider = KumoyDataItemGuiProvider()
         QgsGui.dataItemGuiProviderRegistry().addProvider(self.data_item_gui_provider)
@@ -427,8 +417,6 @@ class KumoyPlugin:
         # Remove translator
         if self.translator:
             QCoreApplication.removeTranslator(self.translator)
-
-        unregister_session_cleared_callback(self._refresh_browser_panel)
 
         QgsApplication.instance().dataItemProviderRegistry().removeProvider(self.dip)
 

--- a/processing/upload_vector/algorithm.py
+++ b/processing/upload_vector/algorithm.py
@@ -25,7 +25,7 @@ import processing
 from ...kumoy import api, constants
 from ...kumoy.api.error import format_api_error
 from ...kumoy.get_token import get_token
-from ...settings_manager import get_settings
+from ...kumoy.settings_manager import get_settings
 from .normalize_field_name import normalize_field_name
 
 

--- a/pyqt_version.py
+++ b/pyqt_version.py
@@ -161,6 +161,14 @@ Qt5: QNetworkRequest.ContentTypeHeader, etc.
 Qt6: QNetworkRequest.KnownHeaders.ContentTypeHeader, etc.
 """
 
+Q_NETWORK_REQUEST_ATTRIBUTE = (
+    QNetworkRequest if QT_VERSION_INT <= 5 else QNetworkRequest.Attribute
+)
+"""Qt network request attribute type
+Qt5: QNetworkRequest.HttpStatusCodeAttribute, etc.
+Qt6: QNetworkRequest.Attribute.HttpStatusCodeAttribute, etc.
+"""
+
 Q_REGION_TYPE = QRegion if QT_VERSION_INT <= 5 else QRegion.RegionType
 """Qt region type
 Qt5: QRegion.Ellipse, etc.

--- a/ui/browser/root.py
+++ b/ui/browser/root.py
@@ -8,7 +8,7 @@ from qgis.PyQt.QtCore import QCoreApplication
 from qgis.PyQt.QtWidgets import QAction, QMessageBox
 from qgis.utils import iface
 
-from ...error_handler import handle_api_error
+from ..error_handler import handle_api_error
 from ...kumoy import api, constants
 from ...pyqt_version import Q_MESSAGEBOX_STD_BUTTON, exec_dialog
 from ...kumoy.settings_manager import get_settings

--- a/ui/browser/root.py
+++ b/ui/browser/root.py
@@ -1,19 +1,17 @@
 from qgis.core import (
-    Qgis,
     QgsDataCollectionItem,
     QgsDataItemProvider,
     QgsDataProvider,
-    QgsMessageLog,
     QgsProject,
 )
 from qgis.PyQt.QtCore import QCoreApplication
 from qgis.PyQt.QtWidgets import QAction, QMessageBox
 from qgis.utils import iface
 
+from ...error_handler import handle_api_error
 from ...kumoy import api, constants
-from ...kumoy.api.error import format_api_error
 from ...pyqt_version import Q_MESSAGEBOX_STD_BUTTON, exec_dialog
-from ...settings_manager import get_settings
+from ...kumoy.settings_manager import get_settings
 from ...ui.dialog_account import DialogAccount
 from ...ui.dialog_login import DialogLogin
 from ...ui.dialog_project_select import ProjectSelectDialog
@@ -61,10 +59,11 @@ class RootCollection(QgsDataCollectionItem):
         try:
             self.load_organization_project()
         except Exception as e:
-            msg = self.tr("Error loading organization/project data: {}").format(
-                format_api_error(e)
+            handle_api_error(
+                e,
+                parent=None,
+                log_prefix=self.tr("Error loading organization/project data"),
             )
-            QgsMessageLog.logMessage(msg, constants.LOG_CATEGORY, Qgis.Warning)
 
     def load_organization_project(self):
         self.organization_data = None
@@ -128,11 +127,11 @@ class RootCollection(QgsDataCollectionItem):
         try:
             self.load_organization_project()
         except Exception as e:
-            msg = self.tr("Error loading organization/project data: {}").format(
-                format_api_error(e)
+            handle_api_error(
+                e,
+                parent=None,
+                log_prefix=self.tr("Error loading organization/project data"),
             )
-            QgsMessageLog.logMessage(msg, constants.LOG_CATEGORY, Qgis.Warning)
-            QMessageBox.critical(None, self.tr("Error"), msg)
 
         self.depopulate()
 
@@ -174,11 +173,11 @@ class RootCollection(QgsDataCollectionItem):
                 self.project_select_dialog.load_organizations()
                 self.project_select_dialog.load_saved_selection()
         except Exception as e:
-            msg = self.tr("Error loading project selection dialog: {}").format(
-                format_api_error(e)
+            handle_api_error(
+                e,
+                parent=None,
+                log_prefix=self.tr("Error loading project selection dialog"),
             )
-            QgsMessageLog.logMessage(msg, constants.LOG_CATEGORY, Qgis.Warning)
-            QMessageBox.critical(None, self.tr("Error"), msg)
             return
 
         result = exec_dialog(self.project_select_dialog)
@@ -206,11 +205,11 @@ class RootCollection(QgsDataCollectionItem):
                 self.account_setting_dialog._load_user_info()
                 self.account_setting_dialog._load_server_config()
         except Exception as e:
-            msg = self.tr("Error loading account settings dialog: {}").format(
-                format_api_error(e)
+            handle_api_error(
+                e,
+                parent=None,
+                log_prefix=self.tr("Error loading account settings dialog"),
             )
-            QgsMessageLog.logMessage(msg, constants.LOG_CATEGORY, Qgis.Warning)
-            QMessageBox.critical(None, self.tr("Error"), msg)
             return
 
         should_logout = exec_dialog(self.account_setting_dialog)

--- a/ui/browser/root.py
+++ b/ui/browser/root.py
@@ -68,6 +68,8 @@ class RootCollection(QgsDataCollectionItem):
     def load_organization_project(self):
         self.organization_data = None
         self.project_data = None
+        # ログアウト/セッション切れ時にも呼ばれるので、まずプレーンな表示名へ戻す。
+        self.setName(constants.PLUGIN_NAME)
 
         settings = get_settings()
         if (

--- a/ui/browser/styledmap.py
+++ b/ui/browser/styledmap.py
@@ -22,13 +22,12 @@ from qgis.PyQt.QtWidgets import (
 )
 from qgis.utils import iface
 
-from ... import settings_manager
+from ...kumoy import settings_manager
+from ...error_handler import handle_api_error
 from ...kumoy import api, constants, local_cache
-from ...kumoy.api.error import format_api_error
-from ...kumoy.local_cache.map import (
-    show_map_save_result,
-    write_qgsfile,
-)
+from ...kumoy.api.error import UnauthorizedError, format_api_error
+from ...kumoy.local_cache.map import write_qgsfile
+from ..project_save_handler import show_map_save_result
 from ...kumoy.sprite import generate_sprite, upload_sprites
 from ...pyqt_version import (
     Q_MESSAGEBOX_STD_BUTTON,
@@ -42,7 +41,7 @@ from ...qgis_version import (
     restore_project_crs_if_invalid,
     restore_xyz_layer_datasources,
 )
-from ...settings_manager import get_settings
+from ...kumoy.settings_manager import get_settings
 from ...ui.layers.convert_vector import (
     convert_local_layers,
 )
@@ -147,17 +146,7 @@ class StyledMapItem(QgsDataItem):
         try:
             styled_map_detail = api.styledmap.get_styled_map(self.styled_map.id)
         except Exception as e:
-            error_text = format_api_error(e)
-            QgsMessageLog.logMessage(
-                self.tr("Error loading map: {}").format(error_text),
-                constants.LOG_CATEGORY,
-                Qgis.Critical,
-            )
-            QMessageBox.critical(
-                None,
-                self.tr("Error"),
-                self.tr("Error loading map: {}").format(error_text),
-            )
+            handle_api_error(e, parent=None, log_prefix=self.tr("Error loading map"))
             return
 
         # XML文字列をQGISプロジェクトにロード
@@ -223,17 +212,7 @@ class StyledMapItem(QgsDataItem):
                 ),
             )
         except Exception as e:
-            error_text = format_api_error(e)
-            QgsMessageLog.logMessage(
-                self.tr("Error updating map: {}").format(error_text),
-                constants.LOG_CATEGORY,
-                Qgis.Critical,
-            )
-            QMessageBox.critical(
-                None,
-                self.tr("Error"),
-                self.tr("Error updating map: {}").format(error_text),
-            )
+            handle_api_error(e, parent=None, log_prefix=self.tr("Error updating map"))
             return
 
         # Itemを更新
@@ -312,17 +291,7 @@ class StyledMapItem(QgsDataItem):
                 update_options,
             )
         except Exception as e:
-            error_text = format_api_error(e)
-            QgsMessageLog.logMessage(
-                self.tr("Error saving map: {}").format(error_text),
-                constants.LOG_CATEGORY,
-                Qgis.Critical,
-            )
-            QMessageBox.critical(
-                None,
-                self.tr("Error"),
-                self.tr("Error saving map: {}").format(error_text),
-            )
+            handle_api_error(e, parent=None, log_prefix=self.tr("Error saving map"))
             return
 
         # Itemを更新
@@ -371,16 +340,8 @@ class StyledMapItem(QgsDataItem):
                     ),
                 )
             except Exception as e:
-                error_text = format_api_error(e)
-                QgsMessageLog.logMessage(
-                    self.tr("Error deleting map: {}").format(error_text),
-                    constants.LOG_CATEGORY,
-                    Qgis.Critical,
-                )
-                QMessageBox.critical(
-                    None,
-                    self.tr("Error"),
-                    self.tr("Failed to delete the map: {}").format(error_text),
+                handle_api_error(
+                    e, parent=None, log_prefix=self.tr("Error deleting map")
                 )
 
     def process_map_cache_clear(self) -> bool:
@@ -612,17 +573,7 @@ class StyledMapRoot(QgsDataItem):
             )
             QgsProject.instance().setDirty(False)
         except Exception as e:
-            error_text = format_api_error(e)
-            QgsMessageLog.logMessage(
-                f"Error adding map: {error_text}",
-                constants.LOG_CATEGORY,
-                Qgis.Critical,
-            )
-            QMessageBox.critical(
-                None,
-                self.tr("Error"),
-                self.tr("Error adding map: {}").format(error_text),
-            )
+            handle_api_error(e, parent=None, log_prefix=self.tr("Error adding map"))
 
     def createChildren(self) -> list[QgsDataItem]:
         project_id = get_settings().selected_project_id
@@ -631,7 +582,18 @@ class StyledMapRoot(QgsDataItem):
             return [ErrorItem(self, self.tr("No project selected"))]
 
         # プロジェクトのスタイルマップを取得
-        styled_maps = api.styledmap.get_styled_maps(project_id)
+        try:
+            styled_maps = api.styledmap.get_styled_maps(project_id)
+        except UnauthorizedError as e:
+            handle_api_error(e, parent=None)
+            return [ErrorItem(self, self.tr("Session expired - please log in"))]
+        except Exception as e:
+            QgsMessageLog.logMessage(
+                f"Error loading maps: {format_api_error(e)}",
+                constants.LOG_CATEGORY,
+                Qgis.Critical,
+            )
+            return [ErrorItem(self, self.tr("Error loading maps"))]
 
         if not styled_maps:
             return [ErrorItem(self, self.tr("No maps available."))]
@@ -775,10 +737,15 @@ def delete_multiple_maps(items: list[StyledMapItem]) -> None:
     deleted_count = 0
     parent_item = items[0].parent() if items else None
 
+    aborted_unauthorized = False
     for item in items:
         try:
             item.process_delete_map()
             deleted_count += 1
+        except UnauthorizedError as e:
+            handle_api_error(e, parent=None)
+            aborted_unauthorized = True
+            break
         except Exception as e:
             error_text = format_api_error(e)
             QgsMessageLog.logMessage(
@@ -790,6 +757,9 @@ def delete_multiple_maps(items: list[StyledMapItem]) -> None:
 
     if parent_item:
         parent_item.refresh()
+
+    if aborted_unauthorized:
+        return
 
     if errors:
         QMessageBox.critical(

--- a/ui/browser/styledmap.py
+++ b/ui/browser/styledmap.py
@@ -23,7 +23,7 @@ from qgis.PyQt.QtWidgets import (
 from qgis.utils import iface
 
 from ...kumoy import settings_manager
-from ...error_handler import handle_api_error
+from ..error_handler import handle_api_error
 from ...kumoy import api, constants, local_cache
 from ...kumoy.api.error import UnauthorizedError, format_api_error
 from ...kumoy.local_cache.map import write_qgsfile

--- a/ui/browser/vector.py
+++ b/ui/browser/vector.py
@@ -31,15 +31,16 @@ from qgis.PyQt.QtWidgets import (
 )
 from qgis.utils import iface
 
+from ...error_handler import handle_api_error
 from ...kumoy import api, constants, local_cache
-from ...kumoy.api.error import format_api_error
+from ...kumoy.api.error import UnauthorizedError, format_api_error
 from ...pyqt_version import (
     Q_MESSAGEBOX_STD_BUTTON,
     QT_DIALOG_BUTTON_CANCEL,
     QT_DIALOG_BUTTON_OK,
     exec_dialog,
 )
-from ...settings_manager import get_settings
+from ...kumoy.settings_manager import get_settings
 from ..icons import (
     BROWSER_FOLDER_ICON,
     BROWSER_GEOMETRY_LINESTRING_ICON,
@@ -152,9 +153,11 @@ class VectorItem(QgsDataItem):
         try:
             self.import_vector()
         except Exception as e:
-            msg = self.tr("Error adding vector to map: {}").format(format_api_error(e))
-            QgsMessageLog.logMessage(msg, constants.LOG_CATEGORY, Qgis.Critical)
-            QMessageBox.critical(None, self.tr("Error"), msg)
+            handle_api_error(
+                e,
+                parent=None,
+                log_prefix=self.tr("Error adding vector to map"),
+            )
 
     def _set_pixel_based_style(self, layer: QgsVectorLayer) -> None:
         """Set pixel-based styling for the layer"""
@@ -271,15 +274,10 @@ class VectorItem(QgsDataItem):
                 ),
             )
         except Exception as e:
-            QgsMessageLog.logMessage(
-                f"Error updating vector: {format_api_error(e)}",
-                constants.LOG_CATEGORY,
-                Qgis.Critical,
-            )
-            QMessageBox.critical(
-                None,
-                self.tr("Error"),
-                self.tr("Error updating vector: {}").format(format_api_error(e)),
+            handle_api_error(
+                e,
+                parent=None,
+                log_prefix=self.tr("Error updating vector"),
             )
             return
 
@@ -317,15 +315,10 @@ class VectorItem(QgsDataItem):
             try:
                 self.process_delete_vector()
             except Exception as e:
-                QgsMessageLog.logMessage(
-                    f"Error deleting vector: {format_api_error(e)}",
-                    constants.LOG_CATEGORY,
-                    Qgis.Critical,
-                )
-                QMessageBox.critical(
-                    None,
-                    self.tr("Error"),
-                    self.tr("Error deleting vector: {}").format(format_api_error(e)),
+                handle_api_error(
+                    e,
+                    parent=None,
+                    log_prefix=self.tr("Error deleting vector"),
                 )
                 return
 
@@ -547,15 +540,10 @@ class VectorRoot(QgsDataItem):
             # Refresh to show new vector
             self.refresh()
         except Exception as e:
-            QgsMessageLog.logMessage(
-                f"Error adding vector: {format_api_error(e)}",
-                constants.LOG_CATEGORY,
-                Qgis.Critical,
-            )
-            QMessageBox.critical(
-                None,
-                self.tr("Error"),
-                self.tr("Error adding vector: {}").format(format_api_error(e)),
+            handle_api_error(
+                e,
+                parent=None,
+                log_prefix=self.tr("Error adding vector"),
             )
 
     def upload_vector(self) -> None:
@@ -577,6 +565,9 @@ class VectorRoot(QgsDataItem):
         # Get vectors for this project
         try:
             vectors = api.vector.get_vectors(project_id)
+        except UnauthorizedError as e:
+            handle_api_error(e, parent=None)
+            return [ErrorItem(self, self.tr("Session expired - please log in"))]
         except Exception as e:
             QgsMessageLog.logMessage(
                 f"Error loading vectors: {format_api_error(e)}",
@@ -654,6 +645,9 @@ def add_multiple_vectors(items: list[VectorItem]) -> None:
     for item in items:
         try:
             item.import_vector()
+        except UnauthorizedError as e:
+            handle_api_error(e, parent=None)
+            return
         except Exception as e:
             error_text = format_api_error(e)
             QgsMessageLog.logMessage(
@@ -727,10 +721,15 @@ def delete_multiple_vectors(items: list[VectorItem]) -> None:
     deleted_count = 0
     parent_item = items[0].parent() if items else None
 
+    aborted_unauthorized = False
     for item in items:
         try:
             item.process_delete_vector()
             deleted_count += 1
+        except UnauthorizedError as e:
+            handle_api_error(e, parent=None)
+            aborted_unauthorized = True
+            break
         except Exception as e:
             error_text = format_api_error(e)
             QgsMessageLog.logMessage(
@@ -744,6 +743,9 @@ def delete_multiple_vectors(items: list[VectorItem]) -> None:
         parent_item.refresh()
 
     iface.mapCanvas().refresh()
+
+    if aborted_unauthorized:
+        return
 
     if errors:
         QMessageBox.critical(

--- a/ui/browser/vector.py
+++ b/ui/browser/vector.py
@@ -31,7 +31,7 @@ from qgis.PyQt.QtWidgets import (
 )
 from qgis.utils import iface
 
-from ...error_handler import handle_api_error
+from ..error_handler import handle_api_error
 from ...kumoy import api, constants, local_cache
 from ...kumoy.api.error import UnauthorizedError, format_api_error
 from ...pyqt_version import (

--- a/ui/dialog_account.py
+++ b/ui/dialog_account.py
@@ -22,7 +22,7 @@ from ..pyqt_version import (
     QT_CURSOR_SHAPE,
     QT_TEXT_INTERACTION,
 )
-from ..settings_manager import store_setting
+from ..kumoy.settings_manager import store_setting
 from .icons import MAIN_ICON
 from .remote_image_label import RemoteImageLabel
 

--- a/ui/dialog_login.py
+++ b/ui/dialog_login.py
@@ -29,7 +29,7 @@ from ..pyqt_version import (
     QT_TEXT_INTERACTION,
     exec_dialog,
 )
-from ..settings_manager import get_settings, store_setting
+from ..kumoy.settings_manager import get_settings, store_setting
 from .dialog_login_success import LoginSuccess
 from .icons import MAIN_ICON
 

--- a/ui/dialog_project_select.py
+++ b/ui/dialog_project_select.py
@@ -25,7 +25,8 @@ from qgis.PyQt.QtWidgets import (
 )
 
 from ..kumoy import api
-from ..kumoy.api.error import format_api_error
+from ..error_handler import handle_api_error
+from ..kumoy.api.error import UnauthorizedError, format_api_error
 from ..kumoy.api.team import TeamDetail
 from ..kumoy.constants import (
     DOCUMENTATION_URL,
@@ -44,7 +45,7 @@ from ..pyqt_version import (
     exec_dialog,
     exec_menu,
 )
-from ..settings_manager import get_settings, store_setting
+from ..kumoy.settings_manager import get_settings, store_setting
 from .dialog_project_edit import ProjectEditDialog
 from .icons import MAP_ICON, RELOAD_ICON, SEARCH_ICON, VECTOR_ICON
 from .remote_image_label import RemoteImageLabel
@@ -446,9 +447,7 @@ class ProjectSelectDialog(QDialog):
         except Exception as e:
             self.myteams = []
             self.admin_team_ids = set()
-            msg = self.tr("Failed to load teams: {}").format(format_api_error(e))
-            QgsMessageLog.logMessage(msg, LOG_CATEGORY, Qgis.Critical)
-            QMessageBox.critical(self, self.tr("Error"), msg)
+            handle_api_error(e, parent=self, log_prefix=self.tr("Failed to load teams"))
 
         # Handle "New Project" button based on admin teams
         has_admin = bool(self.admin_team_ids)
@@ -478,11 +477,11 @@ class ProjectSelectDialog(QDialog):
             # Fetch organization details
             org_detail = api.organization.get_organization(org.id)
         except Exception as e:
-            msg = self.tr("Failed to load organization details. {}").format(
-                format_api_error(e)
+            handle_api_error(
+                e,
+                parent=self,
+                log_prefix=self.tr("Failed to load organization details"),
             )
-            QgsMessageLog.logMessage(msg, LOG_CATEGORY, Qgis.Warning)
-            QMessageBox.critical(self, self.tr("Error"), msg)
             return
 
         # Update usage display
@@ -545,6 +544,9 @@ class ProjectSelectDialog(QDialog):
         try:
             plan_type = org_detail.subscriptionPlan
             plan_limits = api.plan.get_plan_limits(plan_type, org_detail.storageUnits)
+        except UnauthorizedError as e:
+            handle_api_error(e, parent=self)
+            raise
         except Exception as e:
             msg = self.tr("Failed to retrieve plan limits: {}").format(
                 format_api_error(e)
@@ -658,9 +660,9 @@ class ProjectSelectDialog(QDialog):
                 )
 
         except Exception as e:
-            msg = self.tr("Failed to load projects: {}").format(format_api_error(e))
-            QgsMessageLog.logMessage(msg, LOG_CATEGORY, Qgis.Critical)
-            QMessageBox.critical(self, self.tr("Error"), msg)
+            handle_api_error(
+                e, parent=self, log_prefix=self.tr("Failed to load projects")
+            )
 
         self.filter_projects()
 
@@ -733,9 +735,9 @@ class ProjectSelectDialog(QDialog):
             if org_id:
                 self._select_organization_by_id(org_id)
         except Exception as e:
-            msg = self.tr("Failed to reload dialog: {}").format(format_api_error(e))
-            QgsMessageLog.logMessage(msg, LOG_CATEGORY, Qgis.Critical)
-            QMessageBox.critical(self, self.tr("Error"), msg)
+            handle_api_error(
+                e, parent=self, log_prefix=self.tr("Failed to reload dialog")
+            )
             return
         finally:
             org_combo.blockSignals(False)
@@ -790,9 +792,9 @@ class ProjectSelectDialog(QDialog):
                 ),
             )
         except Exception as e:
-            msg = self.tr("Failed to create project: {}").format(format_api_error(e))
-            QgsMessageLog.logMessage(msg, LOG_CATEGORY, Qgis.Critical)
-            QMessageBox.critical(self, self.tr("Error"), msg)
+            handle_api_error(
+                e, parent=self, log_prefix=self.tr("Failed to create project")
+            )
 
     def _select_organization_by_id(self, org_id: str):
         """Select organization by ID in combo box"""
@@ -1039,15 +1041,10 @@ class ProjectItemWidget(QWidget):
                     ),
                 )
             except Exception as e:
-                QgsMessageLog.logMessage(
-                    self.tr("Failed to delete project: {}").format(format_api_error(e)),
-                    LOG_CATEGORY,
-                    Qgis.Critical,
-                )
-                QMessageBox.critical(
-                    self.parent_dialog,
-                    self.tr("Error"),
-                    self.tr("Failed to delete project: {}").format(format_api_error(e)),
+                handle_api_error(
+                    e,
+                    parent=self.parent_dialog,
+                    log_prefix=self.tr("Failed to delete project"),
                 )
 
     def edit_project(self):
@@ -1064,19 +1061,10 @@ class ProjectItemWidget(QWidget):
             # Fetch full project details to get the description
             project_detail = api.project.get_project(self.project.id)
         except Exception as e:
-            QgsMessageLog.logMessage(
-                self.tr("Failed to load project details: {}").format(
-                    format_api_error(e)
-                ),
-                LOG_CATEGORY,
-                Qgis.Critical,
-            )
-            QMessageBox.critical(
-                self.parent_dialog,
-                self.tr("Error"),
-                self.tr("Failed to load project details: {}").format(
-                    format_api_error(e)
-                ),
+            handle_api_error(
+                e,
+                parent=self.parent_dialog,
+                log_prefix=self.tr("Failed to load project details"),
             )
             return
 
@@ -1128,13 +1116,8 @@ class ProjectItemWidget(QWidget):
                 self.tr("Project '{}' has been updated successfully.").format(new_name),
             )
         except Exception as e:
-            QgsMessageLog.logMessage(
-                self.tr("Failed to update project: {}").format(format_api_error(e)),
-                LOG_CATEGORY,
-                Qgis.Critical,
-            )
-            QMessageBox.critical(
-                self.parent_dialog,
-                self.tr("Error"),
-                self.tr("Failed to update project: {}").format(format_api_error(e)),
+            handle_api_error(
+                e,
+                parent=self.parent_dialog,
+                log_prefix=self.tr("Failed to update project"),
             )

--- a/ui/dialog_project_select.py
+++ b/ui/dialog_project_select.py
@@ -25,7 +25,7 @@ from qgis.PyQt.QtWidgets import (
 )
 
 from ..kumoy import api
-from ..error_handler import handle_api_error
+from .error_handler import handle_api_error
 from ..kumoy.api.error import UnauthorizedError, format_api_error
 from ..kumoy.api.team import TeamDetail
 from ..kumoy.constants import (

--- a/ui/dialog_project_select.py
+++ b/ui/dialog_project_select.py
@@ -62,6 +62,19 @@ def _get_usage_color(percentage: float) -> str:
     return "#8bc34a"  # Green
 
 
+def _empty_plan_limits() -> "api.plan.PlanLimits":
+    """API失敗時のフォールバック値。表示は0/0で続行する。"""
+    return api.plan.PlanLimits(
+        maxProjects=0,
+        maxVectors=0,
+        maxStyledMaps=0,
+        maxOrganizationMembers=0,
+        maxVectorFeatures=0,
+        maxVectorAttributes=0,
+        defaultStorageUnits=0,
+    )
+
+
 class ProjectSelectDialog(QDialog):
     """Dialog for selecting projects from organizations"""
 
@@ -546,24 +559,14 @@ class ProjectSelectDialog(QDialog):
             plan_limits = api.plan.get_plan_limits(plan_type, org_detail.storageUnits)
         except UnauthorizedError as e:
             handle_api_error(e, parent=self)
-            raise
+            plan_limits = _empty_plan_limits()
         except Exception as e:
             msg = self.tr("Failed to retrieve plan limits: {}").format(
                 format_api_error(e)
             )
             QgsMessageLog.logMessage(msg, LOG_CATEGORY, Qgis.Critical)
             QMessageBox.warning(self, self.tr("Warning"), msg)
-
-            # Fallback to reasonable defaults if API fails
-            plan_limits = api.plan.PlanLimits(
-                maxProjects=0,
-                maxVectors=0,
-                maxStyledMaps=0,
-                maxOrganizationMembers=0,
-                maxVectorFeatures=0,
-                maxVectorAttributes=0,
-                defaultStorageUnits=0,
-            )
+            plan_limits = _empty_plan_limits()
 
         # Define resource mappings
         resource_mappings = [

--- a/ui/error_handler.py
+++ b/ui/error_handler.py
@@ -1,41 +1,28 @@
 """共通のAPIエラーハンドラ。
 
-UI層の `except Exception` ブロックから呼び出して、
+UI 層・processing 層の `except Exception` ブロックから呼び出して、
 - セッション切れ（UnauthorizedError）の場合はトークンを破棄して再ログインを促す
 - それ以外は従来どおりエラーメッセージを表示する
 を一箇所で行う。
+
+QMessageBox 表示や Browser パネルの再構築など UI 操作を含むため `ui/` 配下に
+置く。`processing/` からの import は sideways（横方向）になるが、
+`error_handler` が UI 責務を負う以上やむを得ない位置取り。
 """
 
-from typing import Callable, List, Optional
+from typing import Optional
 
-from qgis.core import Qgis, QgsMessageLog
+from qgis.core import Qgis, QgsApplication, QgsMessageLog
 from qgis.PyQt.QtCore import QCoreApplication, QTimer
 from qgis.PyQt.QtWidgets import QMessageBox, QWidget
 
-from .kumoy import constants
-from .kumoy.api.error import UnauthorizedError, format_api_error
-from .kumoy.settings_manager import get_settings, store_setting
+from ..kumoy import constants
+from ..kumoy.api.error import UnauthorizedError, format_api_error
+from ..kumoy.settings_manager import get_settings, store_setting
 
 
 def _tr(message: str) -> str:
     return QCoreApplication.translate("@default", message)
-
-
-# セッション切れを検知した際に呼ばれるコールバック群。
-# 主に Browser パネルの再構築（古い Item を消す）に使う想定。
-# error_handler はここに何も登録せず、上位の plugin.py 側が initGui で
-# 登録、unload で解除する。
-_session_cleared_callbacks: List[Callable[[], None]] = []
-
-
-def register_session_cleared_callback(fn: Callable[[], None]) -> None:
-    if fn not in _session_cleared_callbacks:
-        _session_cleared_callbacks.append(fn)
-
-
-def unregister_session_cleared_callback(fn: Callable[[], None]) -> None:
-    if fn in _session_cleared_callbacks:
-        _session_cleared_callbacks.remove(fn)
 
 
 def _clear_session() -> None:
@@ -48,20 +35,24 @@ def _clear_session() -> None:
     store_setting("user_info", "")
 
 
-def _notify_session_cleared() -> None:
-    for cb in list(_session_cleared_callbacks):
-        try:
-            cb()
-        except Exception as e:
-            QgsMessageLog.logMessage(
-                f"session-cleared callback failed: {e}",
-                constants.LOG_CATEGORY,
-                Qgis.Warning,
-            )
+def _refresh_kumoy_browser() -> None:
+    """QGIS の dataItemProviderRegistry を辿って Kumoy provider を見つけ、
+    RootCollection.refresh() を呼ぶ。
+
+    registry は QGIS の公開 API、provider 名は `constants.PLUGIN_NAME` で
+    一意。plugin.py への参照や callback 登録を介さずに直接 UI を更新できる。"""
+    registry = QgsApplication.instance().dataItemProviderRegistry()
+    for provider in registry.providers():
+        if provider.name() != constants.PLUGIN_NAME:
+            continue
+        root = getattr(provider, "root_collection", None)
+        if root is not None:
+            root.refresh()
+        return
 
 
-def _show_session_expired_and_notify() -> None:
-    """セッション切れダイアログを表示し、登録済みコールバックを発火する。
+def _show_session_expired_and_refresh() -> None:
+    """セッション切れダイアログを表示し、Browser パネルをリフレッシュする。
     QTimer.singleShot 経由でメインイベントループの次の tick に呼ばれる前提。"""
     QMessageBox.warning(
         None,
@@ -71,7 +62,7 @@ def _show_session_expired_and_notify() -> None:
             "Please log in again from the Kumoy item in the Browser panel."
         ),
     )
-    _notify_session_cleared()
+    _refresh_kumoy_browser()
 
 
 def handle_api_error(
@@ -82,9 +73,9 @@ def handle_api_error(
     """API例外を共通ハンドリングして表示する。
 
     UnauthorizedError の場合はトークンをクリアした上で、ダイアログ表示と
-    コールバック発火 (Browser パネル再構築) を **次のイベントループ tick に
-    遅延させる**。これは QGIS の `createChildren` のような Python オブジェクトの
-    寿命を巻き込むコンテキストから呼ばれたときに、Browser model から item を
+    Browser パネル再構築を **次のイベントループ tick に遅延させる**。
+    これは QGIS の `createChildren` のような Python オブジェクトの寿命を
+    巻き込むコンテキストから呼ばれたときに、Browser model から item を
     取り除く操作が同期実行されてクラッシュするのを防ぐため。
 
     また、複数の `createChildren` が並行発火して 401 が連発する状況でも
@@ -104,7 +95,7 @@ def handle_api_error(
             Qgis.Warning,
         )
         if not already_cleared:
-            QTimer.singleShot(0, _show_session_expired_and_notify)
+            QTimer.singleShot(0, _show_session_expired_and_refresh)
         return True
 
     detail = format_api_error(exception)

--- a/ui/error_handler.py
+++ b/ui/error_handler.py
@@ -88,13 +88,17 @@ def handle_api_error(
     """
     if isinstance(exception, UnauthorizedError):
         already_cleared = not get_settings().session_token
-        _clear_session()
-        QgsMessageLog.logMessage(
-            _tr("Session expired. Cleared local session token."),
-            constants.LOG_CATEGORY,
-            Qgis.Warning,
-        )
         if not already_cleared:
+            # 実際にトークンを破棄するのは「直前まで有効だった」最初の1回のみ。
+            # それ以降の UnauthorizedError は、無効化済みのトークンに対する
+            # 追加 API 呼び出しが空振りしているだけなので、ログ/ダイアログ/
+            # Browser リフレッシュは抑制する。
+            _clear_session()
+            QgsMessageLog.logMessage(
+                _tr("Session expired. Cleared local session token."),
+                constants.LOG_CATEGORY,
+                Qgis.Warning,
+            )
             QTimer.singleShot(0, _show_session_expired_and_refresh)
         return True
 

--- a/ui/layers/convert_vector.py
+++ b/ui/layers/convert_vector.py
@@ -20,6 +20,7 @@ from qgis.utils import iface
 
 import processing
 
+from ...error_handler import handle_api_error
 from ...kumoy import api, constants
 from ...kumoy.api.error import format_api_error
 from ...pyqt_version import (
@@ -101,12 +102,7 @@ def convert_local_layers(
             org_detail.subscriptionPlan, org_detail.storageUnits
         )
     except Exception as e:
-        error_msg = format_api_error(e)
-        QMessageBox.warning(
-            None,
-            tr("Error"),
-            tr("Failed to check layer limits: {}").format(error_msg),
-        )
+        handle_api_error(e, parent=None, log_prefix=tr("Failed to check layer limits"))
         return (True, [])
 
     current_vector_count = org_detail.usage.vectors

--- a/ui/layers/convert_vector.py
+++ b/ui/layers/convert_vector.py
@@ -20,7 +20,7 @@ from qgis.utils import iface
 
 import processing
 
-from ...error_handler import handle_api_error
+from ..error_handler import handle_api_error
 from ...kumoy import api, constants
 from ...kumoy.api.error import format_api_error
 from ...pyqt_version import (

--- a/ui/project_save_handler.py
+++ b/ui/project_save_handler.py
@@ -1,0 +1,144 @@
+"""QGISの「プロジェクト保存」イベントに連動して Kumoy 側を更新する UI 連携ロジック。
+
+ローカルキャッシュ層 (`kumoy/local_cache/map.py`) は純粋なファイル操作だけを担い、
+ユーザー対話・APIアップロードを伴うこのフローは UI 層に置く。
+"""
+
+import os
+
+from qgis.core import QgsProject
+from qgis.PyQt.QtCore import QCoreApplication
+from qgis.PyQt.QtWidgets import QMessageBox
+from qgis.utils import iface
+
+from ..kumoy import settings_manager
+from ..error_handler import handle_api_error
+from ..kumoy import api
+from ..kumoy.local_cache import map as cache_map
+from ..kumoy.sprite import generate_sprite, upload_sprites
+from ..pyqt_version import Q_MESSAGEBOX_STD_BUTTON
+from .layers.convert_vector import convert_local_layers
+
+
+def tr(message: str, context: str = "@default") -> str:
+    return QCoreApplication.translate(context, message)
+
+
+def show_map_save_result(
+    map_name: str,
+    conversion_errors: list[tuple[str, str]],
+) -> None:
+    """Show success or warning message after map save operation."""
+    if conversion_errors:
+        error_details = "\n".join(
+            [f"• {layer_name}\n{error}\n" for layer_name, error in conversion_errors]
+        )
+        msg_max_length = 1000
+        if len(error_details) > msg_max_length:
+            error_details = error_details[:msg_max_length] + "..."
+
+        report_msg = tr(
+            "Map '{}' has been saved successfully.\n\n"
+            "Warning: {} layers could not be converted:\n\n{}"
+        ).format(map_name, len(conversion_errors), error_details)
+
+        QMessageBox.warning(None, tr("Map Saved with Warnings"), report_msg)
+    else:
+        report_msg = tr("Map '{}' has been saved successfully.").format(map_name)
+        iface.messageBar().pushSuccess(tr("Success"), report_msg)
+
+
+def handle_project_saved() -> None:
+    """Update current project to Kumoy when QGIS project is saved"""
+    # write_qgsfile() 経由の自前保存中は再入を防ぐ
+    if cache_map.is_updating:
+        return
+
+    project = QgsProject.instance()
+
+    custom_vars = project.customVariables()
+    styled_map_id = custom_vars.get("kumoy_map_id")
+    if not styled_map_id:
+        return
+
+    # Check if project file is saved in local cache
+    file_path = os.path.abspath(project.absoluteFilePath())
+    local_cache_dir = os.path.abspath(cache_map._get_cache_dir())
+
+    try:
+        in_cache = os.path.commonpath([file_path, local_cache_dir]) == local_cache_dir
+    except ValueError:
+        in_cache = False
+
+    if not in_cache:
+        QgsProject.instance().setCustomVariables({})
+        return
+
+    # Get and validate map belongs to current project
+    try:
+        styled_map_detail = api.styledmap.get_styled_map(styled_map_id)
+        settings = settings_manager.get_settings()
+
+        if settings.selected_project_id != styled_map_detail.projectId:
+            QMessageBox.critical(
+                None,
+                tr("Wrong Project"),
+                tr(
+                    "This map belongs to a different Kumoy project. "
+                    "Please switch to the correct project."
+                ),
+            )
+            return
+    except Exception as e:
+        handle_api_error(e, parent=None, log_prefix=tr("Error loading map"))
+        return
+
+    if styled_map_detail.role not in ["ADMIN", "OWNER"]:
+        iface.messageBar().pushMessage(
+            tr("Failed"),
+            tr("You do not have permission to save this map to Kumoy."),
+        )
+        return
+
+    confirm = QMessageBox.question(
+        None,
+        tr("Save Map"),
+        tr(
+            "Are you sure you want to overwrite the map '{}' with the current project state?"
+        ).format(styled_map_detail.name),
+        Q_MESSAGEBOX_STD_BUTTON.Yes | Q_MESSAGEBOX_STD_BUTTON.No,
+        Q_MESSAGEBOX_STD_BUTTON.No,
+    )
+    if confirm != Q_MESSAGEBOX_STD_BUTTON.Yes:
+        return
+
+    cancelled, conversion_errors = convert_local_layers(styled_map_detail.projectId)
+    if cancelled:
+        return
+
+    try:
+        qgsproject_str = cache_map.write_qgsfile(styled_map_id)
+
+        sprite_data = generate_sprite(project)
+        new_assets_hash = sprite_data.assets_hash if sprite_data else None
+
+        update_options = api.styledmap.UpdateStyledMapOptions(
+            qgisproject=qgsproject_str,
+        )
+        if new_assets_hash != styled_map_detail.assetsHash:
+            if sprite_data is not None:
+                upload_sprites(styled_map_id, sprite_data)
+            # memo: new_assets_hashがNoneならnullをセットする
+            update_options.assetsHash = new_assets_hash
+        updated_styled_map = api.styledmap.update_styled_map(
+            styled_map_id,
+            update_options,
+        )
+    except Exception as e:
+        handle_api_error(e, parent=None, log_prefix=tr("Error saving map"))
+        return
+
+    QgsProject.instance().setTitle(updated_styled_map.name)
+    QgsProject.instance().setDirty(False)
+
+    show_map_save_result(updated_styled_map.name, conversion_errors)

--- a/ui/project_save_handler.py
+++ b/ui/project_save_handler.py
@@ -63,7 +63,7 @@ def handle_project_saved() -> None:
 
     # Check if project file is saved in local cache
     file_path = os.path.abspath(project.absoluteFilePath())
-    local_cache_dir = os.path.abspath(cache_map._get_cache_dir())
+    local_cache_dir = os.path.abspath(cache_map.get_cache_dir())
 
     try:
         in_cache = os.path.commonpath([file_path, local_cache_dir]) == local_cache_dir
@@ -71,7 +71,10 @@ def handle_project_saved() -> None:
         in_cache = False
 
     if not in_cache:
-        QgsProject.instance().setCustomVariables({})
+        # 他プラグイン/ユーザー定義の customVariables を消さないように
+        # kumoy_map_id だけを除いて書き戻す。
+        new_vars = {k: v for k, v in custom_vars.items() if k != "kumoy_map_id"}
+        QgsProject.instance().setCustomVariables(new_vars)
         return
 
     # Get and validate map belongs to current project

--- a/ui/project_save_handler.py
+++ b/ui/project_save_handler.py
@@ -12,7 +12,7 @@ from qgis.PyQt.QtWidgets import QMessageBox
 from qgis.utils import iface
 
 from ..kumoy import settings_manager
-from ..error_handler import handle_api_error
+from .error_handler import handle_api_error
 from ..kumoy import api
 from ..kumoy.local_cache import map as cache_map
 from ..kumoy.sprite import generate_sprite, upload_sprites


### PR DESCRIPTION
close #514

## Summary

セッション切れ（401/403）時に再ログインを促すダイアログ + ブラウザパネルの自動リフレッシュを実装。あわせて依存方向を整理し CLAUDE.md に規約を追記。

## 主な変更

- **`kumoy/api/client.py`** — HTTP 401/403 を `UnauthorizedError` に変換。トークン未設定時も dict 返却ではなく例外を送出
- **`ui/error_handler.py`** (新規) — 共通 API エラーハンドラ。`UnauthorizedError` 時は `session_token`/`user_info` をクリアし、`QTimer.singleShot(0, ...)` でモーダル表示と Browser リフレッシュを次の event loop tick まで遅延（QGIS の `createChildren` 内から呼ばれてもクラッシュしないよう）。トークン有効→無効の遷移1回だけ通知する dedup あり。リフレッシュは QGIS の公開 API である `dataItemProviderRegistry` 経由で Kumoy provider を見つけて直接 `root_collection.refresh()` を呼ぶ
- **`ui/project_save_handler.py`** (新規) — `handle_project_saved` / `show_map_save_result` を `kumoy/local_cache/map.py` から移設し、`kumoy/ → ui/` の逆向き import を解消
- **`kumoy/settings_manager.py`** — トップレベルから `kumoy/` 配下に移動し、Kumoy ドメインの状態を `kumoy/` 配下に集約
- **`CLAUDE.md`** — 依存方向ルールと `tr()` ヘルパーの慣習を追記。`error_handler` は UI 責務（QMessageBox 表示・Browser リフレッシュ）を持つので `ui/` 配下に置く位置取りを明文化

## Test plan

- [x] `uv run ruff check .` / `uv run ruff format .` 通過
- [x] Docker (`qgis/qgis:3.40`) 上で pytest 95/95 passed
- [x] 実機: session_token を無効化して VectorRoot を展開 → クラッシュせず「Session expired」ダイアログ表示 → 閉じるとブラウザツリーが collapse し「Kumoy」のみ残り「Login」アクションが出る
- [ ] 実機: 再ログインで元の organization/project のまま復帰
- [ ] 実機: ベクター追加・編集・削除、マップ保存、プロジェクト切替で同様の動線が機能