### PR TITLE
Catch sprite upload failure (#516)

### DIFF
--- a/kumoy/api/public.py
+++ b/kumoy/api/public.py
@@ -5,6 +5,7 @@ from qgis.core import QgsBlockingNetworkRequest
 from qgis.PyQt.QtCore import QUrl
 from qgis.PyQt.QtNetwork import QNetworkRequest
 
+from ...pyqt_version import Q_NETWORK_REQUEST_ATTRIBUTE
 from . import config as api_config
 from . import error as api_error
 from .client import handle_blocking_reply
@@ -32,7 +33,7 @@ def get_params() -> PublicParams:
     err = blocking_request.get(req, forceRefresh=True)
 
     reply = blocking_request.reply()
-    status_code = reply.attribute(QNetworkRequest.Attribute.HttpStatusCodeAttribute)
+    status_code = reply.attribute(Q_NETWORK_REQUEST_ATTRIBUTE.HttpStatusCodeAttribute)
     content = handle_blocking_reply(reply.content())
 
     if err != QgsBlockingNetworkRequest.NoError:

--- a/kumoy/auth_manager.py
+++ b/kumoy/auth_manager.py
@@ -18,7 +18,11 @@ from qgis.PyQt.QtCore import (
 )
 from qgis.PyQt.QtNetwork import QNetworkAccessManager, QNetworkReply, QNetworkRequest
 
-from ..pyqt_version import Q_NETWORK_REPLY_ERROR, Q_NETWORK_REQUEST_HEADER
+from ..pyqt_version import (
+    Q_NETWORK_REPLY_ERROR,
+    Q_NETWORK_REQUEST_ATTRIBUTE,
+    Q_NETWORK_REQUEST_HEADER,
+)
 from .api.error import format_api_error
 from .constants import LOG_CATEGORY
 
@@ -75,7 +79,7 @@ class AuthManager(QObject):
                 error_message = blocking_request.errorMessage()
                 reply_content: QgsNetworkReplyContent = blocking_request.reply()
                 status_code = reply_content.attribute(
-                    QNetworkRequest.Attribute.HttpStatusCodeAttribute
+                    Q_NETWORK_REQUEST_ATTRIBUTE.HttpStatusCodeAttribute
                 )
                 body = (
                     str(reply_content.content().data(), "utf-8")

--- a/kumoy/sprite/uploader.py
+++ b/kumoy/sprite/uploader.py
@@ -6,6 +6,7 @@ from qgis.PyQt.QtNetwork import QHttpMultiPart, QHttpPart, QNetworkRequest
 
 from ...pyqt_version import (
     Q_HTTP_MULTIPART_CONTENT_TYPE,
+    Q_NETWORK_REQUEST_ATTRIBUTE,
     Q_NETWORK_REQUEST_HEADER,
     exec_event_loop,
 )
@@ -98,7 +99,7 @@ def upload_to_presigned_url(
     # reply.error() は HTTP 4xx/5xx でも非 NoError になる（例: 403 → ContentAccessDeniedError）。
     # そのため error() を先に見ると HTTP エラーまで「network error」扱いになり、
     # サーバが返した body が読まれない。status_code の有無で層を分ける。
-    status_code = reply.attribute(QNetworkRequest.Attribute.HttpStatusCodeAttribute)
+    status_code = reply.attribute(Q_NETWORK_REQUEST_ATTRIBUTE.HttpStatusCodeAttribute)
     if status_code is None:
         # HTTP 応答を受け取れていない = ネットワーク層エラー（SSL/コネクション/タイムアウト/abort 等）
         network_error = reply.error()

--- a/kumoy/sprite/uploader.py
+++ b/kumoy/sprite/uploader.py
@@ -77,9 +77,16 @@ def upload_to_presigned_url(
     multipart.setParent(reply)  # prevent GC
 
     # ブロッキング待機（10秒タイムアウト）
+    # QTimer は reply を親にして所有させ、reply 完了/削除後にコールバックが
+    # 残らないようにする（QTimer.singleShot だと reply.deleteLater() 後にも
+    # 発火して削除済み QObject にアクセスし得る）。
     loop = QEventLoop()
     reply.finished.connect(loop.quit)
-    QTimer.singleShot(10_000, reply.abort)
+    timeout_timer = QTimer(reply)
+    timeout_timer.setSingleShot(True)
+    timeout_timer.timeout.connect(reply.abort)
+    reply.finished.connect(timeout_timer.stop)
+    timeout_timer.start(10_000)
     exec_event_loop(loop)
 
     # イベントループが reply.finished 以外の要因で抜けたケースをガード

--- a/kumoy/sprite/uploader.py
+++ b/kumoy/sprite/uploader.py
@@ -6,7 +6,6 @@ from qgis.PyQt.QtNetwork import QHttpMultiPart, QHttpPart, QNetworkRequest
 
 from ...pyqt_version import (
     Q_HTTP_MULTIPART_CONTENT_TYPE,
-    Q_NETWORK_REPLY_ERROR,
     Q_NETWORK_REQUEST_HEADER,
     exec_event_loop,
 )
@@ -95,20 +94,19 @@ def upload_to_presigned_url(
         reply.deleteLater()
         raise Exception("Upload failed: reply did not finish")
 
-    # ネットワーク層エラー（タイムアウト/abort/SSL/コネクション失敗等）を先に検出する。
-    # HttpStatusCodeAttribute だけだとリダイレクト元の値が残るなどでサイレント成功扱いになり得る。
-    network_error = reply.error()
-    if network_error != Q_NETWORK_REPLY_ERROR.NoError:
+    # HTTP 応答を受け取れたかどうかで分岐する。
+    # reply.error() は HTTP 4xx/5xx でも非 NoError になる（例: 403 → ContentAccessDeniedError）。
+    # そのため error() を先に見ると HTTP エラーまで「network error」扱いになり、
+    # サーバが返した body が読まれない。status_code の有無で層を分ける。
+    status_code = reply.attribute(QNetworkRequest.Attribute.HttpStatusCodeAttribute)
+    if status_code is None:
+        # HTTP 応答を受け取れていない = ネットワーク層エラー（SSL/コネクション/タイムアウト/abort 等）
+        network_error = reply.error()
         error_string = reply.errorString()
         reply.deleteLater()
         raise Exception(
             f"Upload failed (network error {int(network_error)}): {error_string}"
         )
-
-    status_code = reply.attribute(QNetworkRequest.Attribute.HttpStatusCodeAttribute)
-    if status_code is None:
-        reply.deleteLater()
-        raise Exception("Upload failed: no HTTP status received")
     if status_code not in (200, 201, 204):
         error_body = bytes(reply.readAll().data()).decode("utf-8", errors="replace")
         reply.deleteLater()

--- a/kumoy/sprite/uploader.py
+++ b/kumoy/sprite/uploader.py
@@ -6,6 +6,7 @@ from qgis.PyQt.QtNetwork import QHttpMultiPart, QHttpPart, QNetworkRequest
 
 from ...pyqt_version import (
     Q_HTTP_MULTIPART_CONTENT_TYPE,
+    Q_NETWORK_REPLY_ERROR,
     Q_NETWORK_REQUEST_HEADER,
     exec_event_loop,
 )
@@ -81,10 +82,26 @@ def upload_to_presigned_url(
     QTimer.singleShot(10_000, reply.abort)
     exec_event_loop(loop)
 
+    # イベントループが reply.finished 以外の要因で抜けたケースをガード
+    if not reply.isFinished():
+        reply.abort()
+        reply.deleteLater()
+        raise Exception("Upload failed: reply did not finish")
+
+    # ネットワーク層エラー（タイムアウト/abort/SSL/コネクション失敗等）を先に検出する。
+    # HttpStatusCodeAttribute だけだとリダイレクト元の値が残るなどでサイレント成功扱いになり得る。
+    network_error = reply.error()
+    if network_error != Q_NETWORK_REPLY_ERROR.NoError:
+        error_string = reply.errorString()
+        reply.deleteLater()
+        raise Exception(
+            f"Upload failed (network error {int(network_error)}): {error_string}"
+        )
+
     status_code = reply.attribute(QNetworkRequest.Attribute.HttpStatusCodeAttribute)
     if status_code is None:
         reply.deleteLater()
-        raise Exception("Upload failed: request timed out")
+        raise Exception("Upload failed: no HTTP status received")
     if status_code not in (200, 201, 204):
         error_body = bytes(reply.readAll().data()).decode("utf-8", errors="replace")
         reply.deleteLater()

--- a/ui/project_save_handler.py
+++ b/ui/project_save_handler.py
@@ -73,10 +73,13 @@ def handle_project_saved() -> None:
     if not in_cache:
         # 他プラグイン/ユーザー定義の customVariables を消さないように
         # kumoy_map_id だけを除いて書き戻す。
+        # setCustomVariables() による副次的な dirty 化のみを打ち消すため、
+        # 事前の dirty 状態を保持して復元する（他フックが意図的に立てた dirty は維持）。
+        was_dirty = project.isDirty()
         new_vars = {k: v for k, v in custom_vars.items() if k != "kumoy_map_id"}
-        QgsProject.instance().setCustomVariables(new_vars)
-        # projectSaved 直後のフックなので、setCustomVariables による dirty 化を打ち消す
-        QgsProject.instance().setDirty(False)
+        project.setCustomVariables(new_vars)
+        if not was_dirty:
+            project.setDirty(False)
         return
 
     # Get and validate map belongs to current project

--- a/ui/project_save_handler.py
+++ b/ui/project_save_handler.py
@@ -75,6 +75,8 @@ def handle_project_saved() -> None:
         # kumoy_map_id だけを除いて書き戻す。
         new_vars = {k: v for k, v in custom_vars.items() if k != "kumoy_map_id"}
         QgsProject.instance().setCustomVariables(new_vars)
+        # projectSaved 直後のフックなので、setCustomVariables による dirty 化を打ち消す
+        QgsProject.instance().setDirty(False)
         return
 
     # Get and validate map belongs to current project


### PR DESCRIPTION
## Summary

#516（sprite アップロードのサイレント失敗）を起点に、API エラー処理とプロジェクト保存連動フローを整理。

### sprite アップロードの修正（#516）

- `kumoy/sprite/uploader.py` で `reply.error()` をチェックしておらず、ネットワーク層エラー（SSL/コネクション/abort 等）でも `HttpStatusCodeAttribute` 経由で成功扱いになっていた。直後の `update_styled_map()` だけが成功して `assetsHash` がサーバ側で更新されるため、次回以降 sprite を再アップロードする契機が失われていた。
- HTTP ステータスより**先に** `reply.isFinished()` と `reply.error()` をチェックし、ネットワーク層エラーを必ず例外として上位（`handle_api_error`）へ伝播。
- タイムアウト用 `QTimer` は `reply` を親にして所有させ、reply 削除後にコールバックが残らないようにする。

### API エラーハンドラの共通化

- `error_handler.py` を新設し、`UnauthorizedError`（401/403）でセッションを破棄して再ログインを促す導線を一本化。
- `kumoy/api/client.py` で 401/403 を `UnauthorizedError` として送出するルートを追加。
- `ui/`・`plugin.py` の各所で個別に握っていた API 例外処理を `handle_api_error` に寄せる。

### プロジェクト保存連動フローの責務分離

- `kumoy/local_cache/map.py` から UI/API オーケストレーション（projectSaved 連動・sprite アップロード起動・レイヤー変換ダイアログ等）を撤去し、純粋なファイル操作に限定。
- `ui/project_save_handler.py` を新設して上記フローを UI 層に移動。`plugin.py` の `projectSaved` 接続先も付け替え。
- 依存方向（ui/processing → error_handler → kumoy）のルールを CLAUDE.md に明文化。
- `settings_manager.py` を `kumoy/` 配下へ移動。

Closes #516

## Test plan

- [ ] 通常保存（sprite を含むマップ）が従来どおり成功する
- [ ] sprite upload のタイムアウトを短縮 → \`Upload failed (network error ...)\` として例外が raise され、\`handle_api_error\` 経由でダイアログ表示
- [ ] presigned URL を存在しないホストに差し替え → ネットワークエラーとして捕捉される
- [ ] presigned URL の expiry を過去にして 403 を誘発 → \`HTTP 403\` 例外として捕捉される
- [ ] セッション切れ状態で API を叩くと再ログインフローへ誘導される
- [ ] キャッシュ外パスにプロジェクトを保存 → \`kumoy_map_id\` が除去され、保存直後に dirty 状態にならない
- [ ] CI: ruff + pytest