### PR TITLE
Refresh browser after project selection even when ID is unchanged

### DIFF
--- a/ui/browser/root.py
+++ b/ui/browser/root.py
@@ -187,7 +187,10 @@ class RootCollection(QgsDataCollectionItem):
         if not result:
             return
 
-        # 同一のProjectを選択していない場合はプロジェクトをクリアする
+        # 別Projectを選んだ場合だけ QGIS Project をクリアする。
+        # ただしブラウザ自体は常にリフレッシュする：セッション切れ→再ログインで
+        # 同じプロジェクトを選び直したとき、selected_project_id が変わっていない
+        # ので前者の条件だけだと「Please select a project」表示のまま残ってしまう。
         if prev_project_id != get_settings().selected_project_id:
             QgsProject.instance().clear()
             iface.messageBar().pushSuccess(
@@ -196,7 +199,7 @@ class RootCollection(QgsDataCollectionItem):
                     "Your QGIS project was cleared because the active project changed."
                 ),
             )
-            self.refresh()
+        self.refresh()
 
     def account_settings(self):
         """Show account settings dialog"""


### PR DESCRIPTION
## Summary

- `RootCollection.select_project()` で、プロジェクト選択ダイアログを OK で閉じたときに `prev_project_id != selected_project_id` の条件を満たす場合だけ `self.refresh()` を呼んでいたため、セッション切れ→再ログインで**同じプロジェクト**を選び直したケースでブラウザがリフレッシュされず「Please select a project」表示のまま残っていた。
- 条件を分割：QGIS Project の `clear()` とメッセージバー通知は別Project選択時のみ、`self.refresh()` は accepted で抜けたら常に実行するように変更。

## Test plan

- [ ] ログイン中に 401 を発生させてセッション切れ状態にする → 再ログイン後、**同じプロジェクト**を選択 → ブラウザの Vectors / Maps が再生成されること
- [ ] **別のプロジェクト**を選択 → 「Your QGIS project was cleared...」の通知が出て、ブラウザが新プロジェクトに切り替わること
- [ ] キャンセルで閉じた場合は何も起きないこと