### PR TITLE
fix: QGISプラグインリポジトリのhardcoded password誤検知を解消

### DIFF
--- a/ui/browser/root.py
+++ b/ui/browser/root.py
@@ -74,9 +74,9 @@ class RootCollection(QgsDataCollectionItem):
 
         settings = get_settings()
         if (
-            settings.session_token == ""
-            or settings.selected_organization_id == ""
-            or settings.selected_project_id == ""
+            not settings.session_token
+            or not settings.selected_organization_id
+            or not settings.selected_project_id
         ):
             return
 


### PR DESCRIPTION
## 概要

QGISプラグインリポジトリへのアップロードが、セキュリティスキャナの以下の指摘でブロックされていた：

> /kumoy_qgis_plugin/ui/browser/root.py Line 77
> Possible hardcoded password: ''

`ui/browser/root.py` の `settings.session_token == ""` という空文字リテラル比較が、bandit系スキャナの「ハードコードされたパスワード」パターンに誤検知されていたもの。

## 変更内容

- `== ""` 比較3箇所を truthiness チェック（`not settings.session_token` 等）に変更
- 挙動は同等（`not x` は `""` に加え `None` も弾く）で、同ファイル内の `handleDoubleClick` の既存スタイルとも一致
- 他に token/password 系変数を文字列リテラルと比較している箇所がないことは grep で確認済み