### PR TITLE
fix: 保存したMapの<maplayer>に<extent>が書かれないことがある問題を解消

### DIFF
--- a/kumoy/local_cache/map.py
+++ b/kumoy/local_cache/map.py
@@ -101,26 +101,15 @@ def clear_all() -> bool:
 def refresh_kumoy_layer_extents(project: QgsProject) -> None:
     """Re-read the extent of every Kumoy vector layer from its provider.
 
-    QgsVectorLayer asks the provider for its extent only once and caches the
-    result for the layer's lifetime; QgsProject.write() then serializes that
-    cached value, and omits the <extent> element entirely when it is null.
-    A Kumoy layer reports a null extent whenever the server has none yet (a
-    vector with no features, a freshly uploaded one) or the metadata fetch
-    failed - so a layer whose extent happened to be computed at such a moment
-    is saved without an extent forever after, even once the server knows it.
+    QgsVectorLayer caches the provider extent for the layer's lifetime, and
+    write() omits <extent> entirely when it is null. A Kumoy layer returns null
+    while the server has no extent yet (empty/just-uploaded vector, failed
+    metadata fetch), so a layer unlucky in when it was first asked would be
+    saved without an extent forever after.
 
-    updateExtents() invalidates that cache so extent() queries the provider
-    again, which also folds in any uncommitted edits. It has no effect while
-    featureCount() is 0 though - QgsVectorLayer.extent() skips the provider
-    entirely then - so for a layer that cannot produce features (no local
-    cache) we write the server-side extent onto the layer directly.
-
-    Only Kumoy vector layers are refreshed:
-    - other providers are unaffected by this bug, and recomputing their extents
-      can mean a full scan of the source data.
-    - raster layers have no updateExtents(), and a Kumoy raster's extent is null
-      only while its download failed or was cancelled - in which case the
-      provider still has no data to report at save time either.
+    Vector layers only: other providers don't have this bug and rescanning them
+    can be expensive; QgsRasterLayer has no updateExtents(), and a Kumoy raster
+    is null only when its download failed, which no retry here can fix.
     """
     for layer in project.mapLayers().values():
         if not isinstance(layer, QgsVectorLayer):
@@ -128,9 +117,12 @@ def refresh_kumoy_layer_extents(project: QgsProject) -> None:
         provider = layer.dataProvider()
         if provider is None or provider.name() != DATA_PROVIDER_KEY:
             continue
+        # Preferred: recomputes from the provider and folds in uncommitted edits.
         layer.updateExtents()
         if not layer.extent().isNull():  # also forces the recompute now
             continue
+        # updateExtents() is a no-op while featureCount() is 0, so write the
+        # server extent directly for layers that cannot produce features.
         provider_extent = provider.extent()
         if not provider_extent.isNull():
             layer.setExtent(provider_extent)

--- a/kumoy/local_cache/map.py
+++ b/kumoy/local_cache/map.py
@@ -2,10 +2,16 @@ import os
 import tempfile
 from typing import Optional
 
-from qgis.core import Qgis, QgsApplication, QgsMessageLog, QgsProject
+from qgis.core import (
+    Qgis,
+    QgsApplication,
+    QgsMessageLog,
+    QgsProject,
+    QgsVectorLayer,
+)
 
 from ... import i18n
-from ..constants import LOG_CATEGORY
+from ..constants import DATA_PROVIDER_KEY, LOG_CATEGORY
 from ..sprite import pin_fixed_aspect_ratios
 
 # Flag to prevent double updates when handling the project saved event.
@@ -92,6 +98,38 @@ def clear_all() -> bool:
     return success
 
 
+def refresh_kumoy_layer_extents(project: QgsProject) -> None:
+    """Re-read the extent of every Kumoy vector layer from its provider.
+
+    QgsVectorLayer asks the provider for its extent only once and caches the
+    result for the layer's lifetime; QgsProject.write() then serializes that
+    cached value, and omits the <extent> element entirely when it is null.
+    A Kumoy layer reports a null extent whenever the server has none yet (a
+    vector with no features, a freshly uploaded one) or the metadata fetch
+    failed - so a layer whose extent happened to be computed at such a moment
+    is saved without an extent forever after, even once the server knows it.
+
+    updateExtents() invalidates that cache so extent() queries the provider
+    again. Note it only takes effect while the provider reports a non-zero
+    featureCount() - see KumoyDataProvider.featureCount().
+
+    Only Kumoy vector layers are refreshed:
+    - other providers are unaffected by this bug, and recomputing their extents
+      can mean a full scan of the source data.
+    - raster layers have no updateExtents(), and a Kumoy raster's extent is null
+      only while its download failed or was cancelled - in which case the
+      provider still has no data to report at save time either.
+    """
+    for layer in project.mapLayers().values():
+        if not isinstance(layer, QgsVectorLayer):
+            continue
+        provider = layer.dataProvider()
+        if provider is None or provider.name() != DATA_PROVIDER_KEY:
+            continue
+        layer.updateExtents()
+        layer.extent()  # force the recompute now, not lazily during write()
+
+
 def serialize_project() -> str:
     """Serialize the current project to an XML string via a throwaway temp file.
 
@@ -109,6 +147,7 @@ def serialize_project() -> str:
     global is_updating
     project = QgsProject.instance()
     pin_fixed_aspect_ratios(project)
+    refresh_kumoy_layer_extents(project)
 
     prev_name = project.fileName()
     prev_dirty = project.isDirty()

--- a/kumoy/local_cache/map.py
+++ b/kumoy/local_cache/map.py
@@ -110,8 +110,10 @@ def refresh_kumoy_layer_extents(project: QgsProject) -> None:
     is saved without an extent forever after, even once the server knows it.
 
     updateExtents() invalidates that cache so extent() queries the provider
-    again. Note it only takes effect while the provider reports a non-zero
-    featureCount() - see KumoyDataProvider.featureCount().
+    again, which also folds in any uncommitted edits. It has no effect while
+    featureCount() is 0 though - QgsVectorLayer.extent() skips the provider
+    entirely then - so for a layer that cannot produce features (no local
+    cache) we write the server-side extent onto the layer directly.
 
     Only Kumoy vector layers are refreshed:
     - other providers are unaffected by this bug, and recomputing their extents
@@ -127,7 +129,11 @@ def refresh_kumoy_layer_extents(project: QgsProject) -> None:
         if provider is None or provider.name() != DATA_PROVIDER_KEY:
             continue
         layer.updateExtents()
-        layer.extent()  # force the recompute now, not lazily during write()
+        if not layer.extent().isNull():  # also forces the recompute now
+            continue
+        provider_extent = provider.extent()
+        if not provider_extent.isNull():
+            layer.setExtent(provider_extent)
 
 
 def serialize_project() -> str:

--- a/kumoy/provider/dataprovider.py
+++ b/kumoy/provider/dataprovider.py
@@ -322,14 +322,14 @@ class KumoyDataProvider(QgsVectorDataProvider):
     def featureCount(self) -> int:
         """Return the feature count, respecting subset string if set.
 
-        Falls back to the server-side count when the local cache is
-        unavailable (sync cancelled/failed, cache cleared). Reporting 0 there
-        makes QgsVectorLayer.extent() short-circuit to a null extent, which in
-        turn drops the <extent> element from the saved project - see
-        local_cache.map.refresh_kumoy_layer_extents().
+        0 without a local cache is deliberate, not a missing fallback to the
+        server-side count: KumoyFeatureIterator yields nothing when
+        cached_layer is None, so any other number would contradict
+        getFeatures(). local_cache.map.refresh_kumoy_layer_extents() handles
+        the extent of such a layer without relying on this count.
         """
         if not self.cached_layer:
-            return self.kumoy_vector.count if self.kumoy_vector else 0
+            return 0
         return self.cached_layer.featureCount()
 
     def fields(self) -> QgsFields:

--- a/kumoy/provider/dataprovider.py
+++ b/kumoy/provider/dataprovider.py
@@ -322,11 +322,9 @@ class KumoyDataProvider(QgsVectorDataProvider):
     def featureCount(self) -> int:
         """Return the feature count, respecting subset string if set.
 
-        0 without a local cache is deliberate, not a missing fallback to the
-        server-side count: KumoyFeatureIterator yields nothing when
-        cached_layer is None, so any other number would contradict
-        getFeatures(). local_cache.map.refresh_kumoy_layer_extents() handles
-        the extent of such a layer without relying on this count.
+        0 without a local cache is deliberate, not a missing fallback to
+        kumoy_vector.count: KumoyFeatureIterator yields nothing in that state,
+        so any other number would contradict getFeatures().
         """
         if not self.cached_layer:
             return 0

--- a/kumoy/provider/dataprovider.py
+++ b/kumoy/provider/dataprovider.py
@@ -320,12 +320,7 @@ class KumoyDataProvider(QgsVectorDataProvider):
         return self.providerKey()
 
     def featureCount(self) -> int:
-        """Return the feature count, respecting subset string if set.
-
-        0 without a local cache is deliberate, not a missing fallback to
-        kumoy_vector.count: KumoyFeatureIterator yields nothing in that state,
-        so any other number would contradict getFeatures().
-        """
+        """Return the feature count, respecting subset string if set."""
         if not self.cached_layer:
             return 0
         return self.cached_layer.featureCount()

--- a/kumoy/provider/dataprovider.py
+++ b/kumoy/provider/dataprovider.py
@@ -320,9 +320,16 @@ class KumoyDataProvider(QgsVectorDataProvider):
         return self.providerKey()
 
     def featureCount(self) -> int:
-        """Return the feature count, respecting subset string if set."""
+        """Return the feature count, respecting subset string if set.
+
+        Falls back to the server-side count when the local cache is
+        unavailable (sync cancelled/failed, cache cleared). Reporting 0 there
+        makes QgsVectorLayer.extent() short-circuit to a null extent, which in
+        turn drops the <extent> element from the saved project - see
+        local_cache.map.refresh_kumoy_layer_extents().
+        """
         if not self.cached_layer:
-            return 0
+            return self.kumoy_vector.count if self.kumoy_vector else 0
         return self.cached_layer.featureCount()
 
     def fields(self) -> QgsFields:

--- a/tests/test_map_extent.py
+++ b/tests/test_map_extent.py
@@ -1,0 +1,282 @@
+"""Map保存時に <extent> が書き込まれることのテスト
+
+QgsVectorLayer はプロバイダの extent を一度だけ問い合わせてキャッシュし、
+QgsProject.write() はそのキャッシュ値を書き出す（null なら <extent> 要素そのものが
+欠落する）。Kumoyレイヤーは「サーバ側にまだextentが無い」瞬間に null を返しうるので、
+シリアライズ直前に再計算させる必要がある。
+"""
+
+import re
+import types
+
+import pytest
+
+
+def _extent_block(qgs_str: str, layer_name: str):
+    """Return the <extent> block of the named maplayer, or None if absent."""
+    for m in re.finditer(r"<maplayer.*?</maplayer>", qgs_str, re.S):
+        block = m.group(0)
+        name = re.search(r"<layername>(.*?)</layername>", block)
+        if name is None or name.group(1) != layer_name:
+            continue
+        extent = re.search(r"<extent>.*?</extent>", block, re.S)
+        return extent.group(0) if extent else None
+    raise AssertionError(f"maplayer '{layer_name}' not found in project")
+
+
+@pytest.mark.usefixtures("qgis_plugin_path")
+class TestFeatureCountFallback:
+    """ローカルキャッシュが無いときはサーバ側のcountを返す。
+
+    0 を返すと QgsVectorLayer.extent() が再計算をスキップして null のままになる。
+    """
+
+    def _provider(self, kumoy_vector, cached_layer):
+        from qgis.core import QgsVectorDataProvider
+
+        from plugin_dir.kumoy.provider.dataprovider import KumoyDataProvider
+
+        class _Provider(KumoyDataProvider):
+            def __init__(self):
+                # KumoyDataProvider.__init__ はAPI通信・キャッシュ同期を伴うので飛ばす
+                QgsVectorDataProvider.__init__(self, "")
+                self.kumoy_vector = kumoy_vector
+                self.cached_layer = cached_layer
+
+        return _Provider()
+
+    def test_falls_back_to_server_count_without_cache(self, qgis_app):
+        provider = self._provider(types.SimpleNamespace(count=7), None)
+        assert provider.featureCount() == 7
+
+    def test_zero_without_cache_and_metadata(self, qgis_app):
+        provider = self._provider(None, None)
+        assert provider.featureCount() == 0
+
+    def test_cached_layer_takes_precedence(self, qgis_app):
+        """キャッシュがあればそれが真。空なら 7 ではなく 0 を返す。"""
+        from qgis.core import QgsVectorLayer
+
+        cached = QgsVectorLayer("Point?crs=EPSG:4326", "cache", "memory")
+        provider = self._provider(types.SimpleNamespace(count=7), cached)
+        assert provider.featureCount() == 0
+
+
+@pytest.fixture(scope="session")
+def _registered_fake_provider(qgis_app):
+    """Register a stub provider under the Kumoy vector provider key.
+
+    Mimics KumoyDataProvider: the extent comes from server metadata (null while
+    the server has none) and the feature count from the local cache. Provider
+    metadata can only be registered once per QGIS session, so the stub reads its
+    mutable state from the returned object.
+    """
+    from qgis.core import (
+        QgsCoordinateReferenceSystem,
+        QgsDataProvider,
+        QgsFeatureRequest,
+        QgsField,
+        QgsFields,
+        QgsProviderMetadata,
+        QgsProviderRegistry,
+        QgsRectangle,
+        QgsVectorDataProvider,
+        QgsVectorLayer,
+        QgsWkbTypes,
+    )
+    from qgis.PyQt.QtCore import QVariant
+
+    from plugin_dir.kumoy.constants import DATA_PROVIDER_KEY
+
+    state = types.SimpleNamespace(extent=QgsRectangle(), feature_count=0)
+
+    class _FakeProvider(QgsVectorDataProvider):
+        @classmethod
+        def createProvider(cls, uri, options, flags=QgsDataProvider.ReadFlags()):
+            return _FakeProvider(uri)
+
+        def name(self):
+            return DATA_PROVIDER_KEY
+
+        def isValid(self):
+            return True
+
+        def crs(self):
+            return QgsCoordinateReferenceSystem("EPSG:4326")
+
+        def wkbType(self):
+            return QgsWkbTypes.Point
+
+        def geometryType(self):
+            return QgsWkbTypes.Point
+
+        def fields(self):
+            fields = QgsFields()
+            fields.append(QgsField("kumoy_id", QVariant.LongLong))
+            return fields
+
+        def extent(self):
+            return state.extent
+
+        def featureCount(self):
+            return state.feature_count
+
+        def getFeatures(self, request=QgsFeatureRequest()):
+            empty = QgsVectorLayer("Point?crs=EPSG:4326", "empty", "memory")
+            return empty.getFeatures(request)
+
+        def capabilities(self):
+            return QgsVectorDataProvider.Capabilities()
+
+    # 同一キーの二重登録は False になるだけで無害
+    QgsProviderRegistry.instance().registerProvider(
+        QgsProviderMetadata(
+            DATA_PROVIDER_KEY, "fake kumoy provider", _FakeProvider.createProvider
+        )
+    )
+    return state
+
+
+@pytest.fixture
+def fake_kumoy_provider(_registered_fake_provider):
+    """Reset the stub provider's state for each test."""
+    from qgis.core import QgsRectangle
+
+    _registered_fake_provider.extent = QgsRectangle()
+    _registered_fake_provider.feature_count = 0
+    return _registered_fake_provider
+
+
+def _make_tif(path: str):
+    from osgeo import gdal, osr
+
+    ds = gdal.GetDriverByName("GTiff").Create(path, 8, 8, 1, gdal.GDT_Byte)
+    srs = osr.SpatialReference()
+    srs.ImportFromEPSG(4326)
+    ds.SetProjection(srs.ExportToWkt())
+    ds.SetGeoTransform([10.0, 0.1, 0, 50.0, 0, -0.1])
+    ds.Close()
+
+
+@pytest.fixture(scope="session")
+def _registered_raster_metadata(qgis_app):
+    from qgis.core import QgsProviderRegistry
+
+    from plugin_dir.kumoy.provider.raster_dataprovider_metadata import (
+        KumoyRasterProviderMetadata,
+    )
+
+    # 同一キーの二重登録は False になるだけで無害
+    QgsProviderRegistry.instance().registerProvider(KumoyRasterProviderMetadata())
+
+
+@pytest.mark.usefixtures("qgis_plugin_path")
+class TestSerializeProjectExtent:
+    @pytest.fixture
+    def kumoy_raster_layer(
+        self, _registered_raster_metadata, monkeypatch, tmp_path, kumoy_layer
+    ):
+        """Kumoyラスタレイヤーをプロジェクトに追加する（kumoy_layer の後に追加）。"""
+        from qgis.core import QgsProject, QgsRasterLayer
+
+        from plugin_dir.kumoy import constants
+        from plugin_dir.kumoy.provider import raster_dataprovider as rp
+
+        path = str(tmp_path / "r-1.tif")
+        _make_tif(path)
+        monkeypatch.setattr(rp.local_cache.raster, "is_cached", lambda rid: True)
+        monkeypatch.setattr(rp.local_cache.raster, "get_cache_path", lambda rid: path)
+
+        layer = QgsRasterLayer(
+            "project_id=p-1;raster_id=r-1;raster_name=dem;",
+            "dem",
+            constants.RASTER_DATA_PROVIDER_KEY,
+        )
+        assert layer.isValid()
+        assert layer.dataProvider().name() == constants.RASTER_DATA_PROVIDER_KEY
+        QgsProject.instance().addMapLayer(layer)
+        return layer
+
+    @pytest.fixture
+    def kumoy_layer(self, fake_kumoy_provider):
+        from qgis.core import QgsProject, QgsVectorLayer
+
+        from plugin_dir.kumoy.constants import DATA_PROVIDER_KEY
+
+        project = QgsProject.instance()
+        project.clear()
+        layer = QgsVectorLayer(
+            "project_id=p-1;vector_id=v-1;vector_name=points;vector_type=POINT;",
+            "points",
+            DATA_PROVIDER_KEY,
+        )
+        assert layer.isValid()
+        project.addMapLayer(layer)
+        yield layer
+        project.clear()
+
+    def test_extent_written(self, kumoy_layer, fake_kumoy_provider):
+        from qgis.core import QgsRectangle
+
+        from plugin_dir.kumoy.local_cache.map import serialize_project
+
+        fake_kumoy_provider.extent = QgsRectangle(139.0, 35.0, 140.0, 36.0)
+        fake_kumoy_provider.feature_count = 3
+
+        block = _extent_block(serialize_project(), "points")
+        assert block is not None
+        assert "<xmin>139</xmin>" in block
+
+    def test_extent_recovered_after_null_was_cached(
+        self, kumoy_layer, fake_kumoy_provider
+    ):
+        """空のVectorに地物を追加したあと保存するケース。
+
+        レイヤー追加直後の描画で null がキャッシュされても、保存時には
+        サーバ側の extent が書き込まれること。
+        """
+        from qgis.core import QgsRectangle
+
+        from plugin_dir.kumoy.local_cache.map import serialize_project
+
+        assert kumoy_layer.extent().isNull()  # ここで null がキャッシュされる
+
+        fake_kumoy_provider.extent = QgsRectangle(139.0, 35.0, 140.0, 36.0)
+        fake_kumoy_provider.feature_count = 3
+
+        block = _extent_block(serialize_project(), "points")
+        assert block is not None
+        assert "<xmin>139</xmin>" in block
+
+    def test_kumoy_raster_layer_does_not_break_serialization(
+        self, kumoy_layer, fake_kumoy_provider, kumoy_raster_layer
+    ):
+        """QgsRasterLayer に updateExtents() は無いので、触ってはいけない。"""
+        from qgis.core import QgsRectangle
+
+        from plugin_dir.kumoy.local_cache.map import serialize_project
+
+        fake_kumoy_provider.extent = QgsRectangle(139.0, 35.0, 140.0, 36.0)
+        fake_kumoy_provider.feature_count = 3
+
+        qgs_str = serialize_project()
+
+        block = _extent_block(qgs_str, "points")
+        assert block is not None
+        assert "<xmin>139</xmin>" in block
+        assert _extent_block(qgs_str, "dem") is not None
+
+    def test_stale_extent_updated(self, kumoy_layer, fake_kumoy_provider):
+        from qgis.core import QgsRectangle
+
+        from plugin_dir.kumoy.local_cache.map import serialize_project
+
+        fake_kumoy_provider.extent = QgsRectangle(0.0, 0.0, 1.0, 1.0)
+        fake_kumoy_provider.feature_count = 1
+        assert not kumoy_layer.extent().isNull()
+
+        fake_kumoy_provider.extent = QgsRectangle(139.0, 35.0, 140.0, 36.0)
+
+        block = _extent_block(serialize_project(), "points")
+        assert block is not None
+        assert "<xmin>139</xmin>" in block

--- a/tests/test_map_extent.py
+++ b/tests/test_map_extent.py
@@ -1,9 +1,8 @@
 """Map保存時に <extent> が書き込まれることのテスト
 
-QgsVectorLayer はプロバイダの extent を一度だけ問い合わせてキャッシュし、
-QgsProject.write() はそのキャッシュ値を書き出す（null なら <extent> 要素そのものが
-欠落する）。Kumoyレイヤーは「サーバ側にまだextentが無い」瞬間に null を返しうるので、
-シリアライズ直前に再計算させる必要がある。
+QgsVectorLayer はプロバイダの extent を一度だけ問い合わせてキャッシュし、write() は
+その値を書き出す（null なら <extent> 要素が丸ごと欠落する）。Kumoyレイヤーは
+サーバ側にまだextentが無い瞬間に null を返しうるので、保存直前に再計算が必要。
 """
 
 import re
@@ -28,9 +27,8 @@ def _extent_block(qgs_str: str, layer_name: str):
 class TestFeatureCount:
     """ローカルキャッシュが無いときは 0。
 
-    KumoyFeatureIterator は cached_layer が None なら0件しか返さないので、
-    サーバ側の count を返すと getFeatures() と矛盾する。extent の面倒は
-    refresh_kumoy_layer_extents() が featureCount() に依存せず見る。
+    KumoyFeatureIterator が0件しか返さないので、サーバ側の count を返すと
+    getFeatures() と矛盾する。
     """
 
     def _provider(self, kumoy_vector, cached_layer):
@@ -71,10 +69,8 @@ class TestFeatureCount:
 def _registered_fake_provider(qgis_app):
     """Register a stub provider under the Kumoy vector provider key.
 
-    Mimics KumoyDataProvider: the extent comes from server metadata (null while
-    the server has none) and the feature count from the local cache. Provider
-    metadata can only be registered once per QGIS session, so the stub reads its
-    mutable state from the returned object.
+    Provider metadata can only be registered once per QGIS session, so the stub
+    reads its extent / feature count from the returned mutable object.
     """
     from qgis.core import (
         QgsCoordinateReferenceSystem,
@@ -235,11 +231,7 @@ class TestSerializeProjectExtent:
     def test_extent_recovered_after_null_was_cached(
         self, kumoy_layer, fake_kumoy_provider
     ):
-        """空のVectorに地物を追加したあと保存するケース。
-
-        レイヤー追加直後の描画で null がキャッシュされても、保存時には
-        サーバ側の extent が書き込まれること。
-        """
+        """レイヤー追加直後の描画で null がキャッシュされても復旧すること。"""
         from qgis.core import QgsRectangle
 
         from plugin_dir.kumoy.local_cache.map import serialize_project
@@ -272,12 +264,7 @@ class TestSerializeProjectExtent:
         assert _extent_block(qgs_str, "dem") is not None
 
     def test_extent_written_without_local_cache(self, kumoy_layer, fake_kumoy_provider):
-        """地物を返せないレイヤーでもサーバの extent は書き込まれること。
-
-        ローカルキャッシュ同期が失敗した／キャッシュを消した直後の状態。
-        featureCount() が 0 なので updateExtents() は効かず、
-        setExtent() 経由で書き込む必要がある。
-        """
+        """キャッシュ同期失敗時。featureCount() が 0 だと updateExtents() は効かない。"""
         from qgis.core import QgsRectangle
 
         from plugin_dir.kumoy.local_cache.map import serialize_project

--- a/tests/test_map_extent.py
+++ b/tests/test_map_extent.py
@@ -25,10 +25,12 @@ def _extent_block(qgs_str: str, layer_name: str):
 
 
 @pytest.mark.usefixtures("qgis_plugin_path")
-class TestFeatureCountFallback:
-    """ローカルキャッシュが無いときはサーバ側のcountを返す。
+class TestFeatureCount:
+    """ローカルキャッシュが無いときは 0。
 
-    0 を返すと QgsVectorLayer.extent() が再計算をスキップして null のままになる。
+    KumoyFeatureIterator は cached_layer が None なら0件しか返さないので、
+    サーバ側の count を返すと getFeatures() と矛盾する。extent の面倒は
+    refresh_kumoy_layer_extents() が featureCount() に依存せず見る。
     """
 
     def _provider(self, kumoy_vector, cached_layer):
@@ -45,21 +47,24 @@ class TestFeatureCountFallback:
 
         return _Provider()
 
-    def test_falls_back_to_server_count_without_cache(self, qgis_app):
+    def test_zero_without_cache_even_if_server_has_count(self, qgis_app):
         provider = self._provider(types.SimpleNamespace(count=7), None)
-        assert provider.featureCount() == 7
-
-    def test_zero_without_cache_and_metadata(self, qgis_app):
-        provider = self._provider(None, None)
         assert provider.featureCount() == 0
 
-    def test_cached_layer_takes_precedence(self, qgis_app):
-        """キャッシュがあればそれが真。空なら 7 ではなく 0 を返す。"""
-        from qgis.core import QgsVectorLayer
+    def test_uses_cached_layer_when_available(self, qgis_app):
+        """キャッシュがあればサーバ側の count ではなくキャッシュの件数が真。"""
+        from qgis.core import QgsFeature, QgsGeometry, QgsPointXY, QgsVectorLayer
 
         cached = QgsVectorLayer("Point?crs=EPSG:4326", "cache", "memory")
+        feats = []
+        for x in (139.0, 139.5):
+            f = QgsFeature(cached.fields())
+            f.setGeometry(QgsGeometry.fromPointXY(QgsPointXY(x, 35.0)))
+            feats.append(f)
+        assert cached.dataProvider().addFeatures(feats)[0]
+
         provider = self._provider(types.SimpleNamespace(count=7), cached)
-        assert provider.featureCount() == 0
+        assert provider.featureCount() == 2
 
 
 @pytest.fixture(scope="session")
@@ -265,6 +270,32 @@ class TestSerializeProjectExtent:
         assert block is not None
         assert "<xmin>139</xmin>" in block
         assert _extent_block(qgs_str, "dem") is not None
+
+    def test_extent_written_without_local_cache(self, kumoy_layer, fake_kumoy_provider):
+        """地物を返せないレイヤーでもサーバの extent は書き込まれること。
+
+        ローカルキャッシュ同期が失敗した／キャッシュを消した直後の状態。
+        featureCount() が 0 なので updateExtents() は効かず、
+        setExtent() 経由で書き込む必要がある。
+        """
+        from qgis.core import QgsRectangle
+
+        from plugin_dir.kumoy.local_cache.map import serialize_project
+
+        assert kumoy_layer.extent().isNull()  # null がキャッシュされる
+
+        fake_kumoy_provider.extent = QgsRectangle(139.0, 35.0, 140.0, 36.0)
+        fake_kumoy_provider.feature_count = 0
+
+        block = _extent_block(serialize_project(), "points")
+        assert block is not None
+        assert "<xmin>139</xmin>" in block
+
+    def test_null_provider_extent_left_alone(self, kumoy_layer, fake_kumoy_provider):
+        """サーバもextentを知らないなら、書ける値が無いので何もしない。"""
+        from plugin_dir.kumoy.local_cache.map import serialize_project
+
+        assert _extent_block(serialize_project(), "points") is None
 
     def test_stale_extent_updated(self, kumoy_layer, fake_kumoy_provider):
         from qgis.core import QgsRectangle

--- a/ui/browser/styledmap.py
+++ b/ui/browser/styledmap.py
@@ -253,10 +253,6 @@ class StyledMapItem(QgsDataItem):
                 )
                 return
 
-        # HACK: to ensure extents of all layers are calculated - Issue #311
-        for layer in QgsProject.instance().mapLayers().values():
-            layer.extent()
-
         # Pre-flight size check before any upload: serialize to a throwaway temp
         # file and validate, without touching the cache. The .qgs size barely
         # changes after conversion (only datasource strings are swapped), so
@@ -455,10 +451,6 @@ class StyledMapRoot(QgsDataItem):
         """Add a new map to kumoy server
         Options:
         clear - whether to clear current QGIS project"""
-
-        # HACK: to ensure extents of all layers are calculated - Issue #311
-        for layer in QgsProject.instance().mapLayers().values():
-            layer.extent()
 
         try:
             # Check plan limits before creating styled map


### PR DESCRIPTION
## 問題

保存したMapの `<maplayer>` に `<extent>` が書かれないことがある。

`QgsVectorLayer` はプロバイダの extent を**最初の1回だけ**問い合わせて生涯キャッシュし、`write()` はその値を書き出す（null なら要素が丸ごと欠落）。Kumoyレイヤーはサーバ側にまだ extent が無い瞬間（地物0件・アップロード直後・メタデータ取得失敗）に null を返すため、そのタイミングで最初に聞かれたレイヤーは以後ずっと extent 無しで保存され続ける。

`layer.extent()` の再呼び出し・`reload()`・`setDataSource()`・`dataChanged` はいずれも再問い合わせを起こさない（プロバイダ呼び出し回数0を確認）。効くのは `updateExtents()` だけで、しかも `featureCount() > 0` のときのみ。

## 修正

`serialize_project()` の冒頭で Kumoyベクタレイヤーの extent を再計算する `refresh_kumoy_layer_extents()` を追加。

```python
layer.updateExtents()                    # 第一選択（未コミットの編集も畳み込む）
if layer.extent().isNull():              # featureCount() が 0 だと効かない
    if not provider.extent().isNull():
        layer.setExtent(provider.extent())   # サーバの extent を直接書き込む
```

3つの保存経路（`apply_qgisproject_to_styledmap` / `add_styled_map` / `handle_project_saved`）はすべて `convert_local_layers()` の**後**に `serialize_project()` を通るので、変換で新規生成されたレイヤーも、これまで extent 対応が無かった Ctrl+S 経路もまとめて対象になる。

効かない上に null を早期固定していた `styledmap.py` の `layer.extent()` HACK（Issue #311）は廃止。

### ベクタ限定にした理由

`QgsRasterLayer` に `updateExtents()` は無い。またKumoyラスタの extent が null になるのはDL失敗・中断時だけで、保存時点でもプロバイダに返せるデータが無いため再計算しても得るものが無い。

### featureCount() を触らなかった理由

当初は `cached_layer` が無いとき `kumoy_vector.count` にフォールバックする案だったが撤回した。`KumoyFeatureIterator` は `cached_layer is None` で0件しか返さないので、`getFeatures()` と矛盾する嘘になる。`setExtent()` は `featureCount()` を経由せず効くので、そもそも不要だった。

## テスト

`tests/test_map_extent.py`（8ケース）。`.qgs` から該当 `<maplayer>` の `<extent>` を抜き出して検証。

- null がキャッシュされた後の復旧 / 古い extent の更新 / キャッシュ無し（`featureCount()` 0）でも書かれる / サーバも知らないなら何もしない
- Kumoyラスタ混在時に壊れないこと
- `featureCount()` がキャッシュ無しで 0 を返すこと

`setExtent()` の分岐とラスタのガードは、それぞれ外すと該当テストが実際に FAIL することを確認済み。全件 `172 passed, 1 skipped`（CI matrix の 3.44 / 4.0-trixie 両方）。

## 残件

`_reload_vector()` 後にレイヤーへ extent 再計算を促す処理は入れていない。保存時に上記が拾うので `.qgs` の内容には影響せず、残るのは保存前の「レイヤーにズーム」だけ。