### PR TITLE
fix: Kumoy以外のレイヤーにKumoyアイコンが付くのを直す

### DIFF
--- a/i18n/ja.json
+++ b/i18n/ja.json
@@ -181,6 +181,7 @@
   "Invalid destination project selection.": "宛先プロジェクトの選択が正しくありません。",
   "Invalid input layer": "無効な入力レイヤ",
   "Kumoy Upload": "Kumoy アップロード",
+  "Kumoy layer": "Kumoy レイヤー",
   "Layer '{}' converted to Kumoy successfully.": "レイヤー「{}」がKumoyに正常に変換されました。",
   "Layer is invalid: {}": "不正なレイヤ： {}",
   "Load Map": "マップを読み込む",

--- a/ui/layers/indicators.py
+++ b/ui/layers/indicators.py
@@ -2,10 +2,13 @@ from qgis.core import QgsProject
 from qgis.gui import QgsLayerTreeViewIndicator
 from qgis.utils import iface
 
+from ... import i18n
 from ...kumoy.constants import DATA_PROVIDER_KEY, RASTER_DATA_PROVIDER_KEY
 from ..icons import MAIN_ICON
 
-_KUMOY_TOOLTIP = "Kumoy layer"
+# Marker property, not the tooltip: the tooltip is translated and must not be
+# relied on to identify our own indicators.
+_KUMOY_INDICATOR_PROPERTY = "kumoyIndicator"
 
 
 def update_kumoy_indicator():
@@ -24,7 +27,8 @@ def update_kumoy_indicator():
             if existing:
                 continue
             indicator = QgsLayerTreeViewIndicator(view)
-            indicator.setToolTip(_KUMOY_TOOLTIP)
+            indicator.setProperty(_KUMOY_INDICATOR_PROPERTY, True)
+            indicator.setToolTip(i18n.tr("Kumoy layer"))
             indicator.setIcon(MAIN_ICON)
             view.addIndicator(node, indicator)
         else:
@@ -39,4 +43,4 @@ def update_kumoy_indicator():
 def _kumoy_indicators(node):
     """Return Kumoy indicators set on the given node."""
     view = iface.layerTreeView()
-    return [i for i in view.indicators(node) if i.toolTip() == _KUMOY_TOOLTIP]
+    return [i for i in view.indicators(node) if i.property(_KUMOY_INDICATOR_PROPERTY)]

--- a/ui/layers/indicators.py
+++ b/ui/layers/indicators.py
@@ -9,7 +9,7 @@ _KUMOY_TOOLTIP = "Kumoy layer"
 
 
 def update_kumoy_indicator():
-    """Set Kumoy icon as indicator on Kumoy provided layer"""
+    """Ensure the Kumoy indicator is present on Kumoy layers and removed from other nodes."""
     root = QgsProject.instance().layerTreeRoot()
     view = iface.layerTreeView()
 

--- a/ui/layers/indicators.py
+++ b/ui/layers/indicators.py
@@ -5,31 +5,38 @@ from qgis.utils import iface
 from ...kumoy.constants import DATA_PROVIDER_KEY, RASTER_DATA_PROVIDER_KEY
 from ..icons import MAIN_ICON
 
+_KUMOY_TOOLTIP = "Kumoy layer"
+
 
 def update_kumoy_indicator():
     """Set Kumoy icon as indicator on Kumoy provided layer"""
     root = QgsProject.instance().layerTreeRoot()
     view = iface.layerTreeView()
 
-    for layer in QgsProject.instance().mapLayers().values():
-        if layer.providerType() not in (DATA_PROVIDER_KEY, RASTER_DATA_PROVIDER_KEY):
-            continue
-        node = root.findLayer(layer.id())
-        if not node:
-            continue
-        if _has_kumoy_indicator(node):
-            continue
-        indicator = QgsLayerTreeViewIndicator(view)
-        indicator.setToolTip("Kumoy layer")
-        indicator.setIcon(MAIN_ICON)
-        view.addIndicator(node, indicator)
+    for node in root.findLayers():
+        layer = node.layer()
+        is_kumoy = layer is not None and layer.providerType() in (
+            DATA_PROVIDER_KEY,
+            RASTER_DATA_PROVIDER_KEY,
+        )
+        existing = _kumoy_indicators(node)
+        if is_kumoy:
+            if existing:
+                continue
+            indicator = QgsLayerTreeViewIndicator(view)
+            indicator.setToolTip(_KUMOY_TOOLTIP)
+            indicator.setIcon(MAIN_ICON)
+            view.addIndicator(node, indicator)
+        else:
+            # QgsLayerTreeView keys indicators by node pointer and never drops
+            # entries for destroyed nodes, so a reused address would otherwise
+            # inherit a Kumoy icon. Remove them explicitly.
+            for indicator in existing:
+                view.removeIndicator(node, indicator)
+                indicator.deleteLater()
 
 
-def _has_kumoy_indicator(node):
-    """Check if the given node has Kumoy indicator set."""
+def _kumoy_indicators(node):
+    """Return Kumoy indicators set on the given node."""
     view = iface.layerTreeView()
-    indicators = view.indicators(node)
-    for indicator in indicators:
-        if indicator.toolTip() == "Kumoy layer":
-            return True
-    return False
+    return [i for i in view.indicators(node) if i.toolTip() == _KUMOY_TOOLTIP]


### PR DESCRIPTION
## 概要

ブラウザパネル（レイヤーツリー）で、Kumoy以外のレイヤーにもKumoyアイコンのインジケータが付いてしまうことがある問題を修正します。

## 原因

`update_kumoy_indicator()` はインジケータの**追加しか行っていません**でした。`removedChildren` シグナルにも接続されていますが、呼ばれる関数が追加専用なので削除時に何も掃除されません。

`QgsLayerTreeView` はインジケータを `QHash<QgsLayerTreeNode*, QList<QgsLayerTreeViewIndicator*>>` で**ノードのポインタをキーに**保持し、ノードが破棄されてもエントリを自動削除しません（QGIS本体の `QgsLayerTreeViewIndicatorProvider` がレイヤー削除時に明示的に `removeIndicator()` を呼んでいるのも同じ理由）。

そのため:

1. Kumoyレイヤーを削除 → ノードは破棄されるがエントリは残る（インジケータ自体は view に親付けされているため生存）
2. 別のレイヤーを追加 → 新しい `QgsLayerTreeLayer` が解放済みの同じアドレスに再確保されることがある
3. その非Kumoyレイヤーが古いエントリを引き継ぎ、Kumoyアイコンが表示される

レイヤーツリー内のドラッグ&ドロップ移動でもノードは作り直されるので同じ経路になります。散発的にしか起きないのは、アロケータがアドレスを再利用するかどうかに依存するためです。

## 変更内容

- Kumoyでないノードに Kumoy インジケータが残っていれば `removeIndicator()` + `deleteLater()` で明示的に除去（誤アイコンの直接の修正）
- 走査を `mapLayers()` → `root.findLayers()` に変更し、レイヤーツリーに実在するノードだけを対象にした
- `_has_kumoy_indicator` を `_kumoy_indicators`（該当インジケータのリストを返す）に置き換え
- ツールチップ文字列を `_KUMOY_TOOLTIP` 定数に集約

毎回すべてのノードを再評価するので、ノードポインタが再利用されても状態が収束します。

## 動作確認

- `ruff format` / `ruff check` 通過
- インジケータに関するテストは既存にないため追加の影響なし（ローカルでのDockerテストは未実行、CIに委ねます）