### PR TITLE
Fix negative time diff for recent project update 

### DIFF
--- a/i18n/ja.json
+++ b/i18n/ja.json
@@ -182,6 +182,7 @@
   "Invalid Layer": "無効なレイヤ",
   "Invalid destination project selection.": "宛先プロジェクトの選択が正しくありません。",
   "Invalid input layer": "無効な入力レイヤ",
+  "Just now": "たった今",
   "Kumoy Upload": "Kumoy アップロード",
   "Kumoy layer": "Kumoy レイヤー",
   "Layer '{}' converted to Kumoy successfully.": "レイヤー「{}」がKumoyに正常に変換されました。",

--- a/ui/dialog_project_select.py
+++ b/ui/dialog_project_select.py
@@ -1004,6 +1004,9 @@ class ProjectItemWidget(QWidget):
         now = datetime.now(dt.tzinfo)
         delta = now - dt
 
+        if delta.total_seconds() < 60:
+            return i18n.tr("Just now")
+
         if delta.days == 0:
             if delta.seconds < 3600:
                 return i18n.tr("{} minutes ago").format(delta.seconds // 60)


### PR DESCRIPTION
<!-- Close or Related Issues -->
Close #554 

### What I did
<!-- Please describe the motivation behind this PR and the changes it introduces. -->
Fix potential negative timediff between server and QGIS
(replace "0 minutes" or "-1 days" by "Just now")
<img width="549" height="370" alt="image" src="https://github.com/user-attachments/assets/b0b61052-bdc8-49ed-98f5-cda1ee397e67" />

