### PR TITLE
fix: QGIS 4でリモート画像（アバター・アイコン・サムネイル）が表示されない問題を修正

### DIFF
--- a/kumoy/api/user.py
+++ b/kumoy/api/user.py
@@ -1,6 +1,7 @@
 from dataclasses import dataclass
 from typing import Optional
 
+from . import config as api_config
 from .client import ApiClient
 
 
@@ -32,3 +33,12 @@ def get_me() -> User:
         createdAt=response.get("createdAt", ""),
         updatedAt=response.get("updatedAt", ""),
     )
+
+
+def resolve_avatar_url(avatar_image: str) -> str:
+    """Build a displayable URL from the avatarImage returned by the API"""
+    # The server returns an absolute URL for external providers (Google etc.)
+    # and a server-relative path for self-hosted storage
+    if avatar_image.startswith(("http://", "https://")):
+        return avatar_image
+    return api_config.get_api_config().SERVER_URL.rstrip("/") + avatar_image

--- a/kumoy/download.py
+++ b/kumoy/download.py
@@ -122,7 +122,7 @@ def download_to_file(
     if status_code is None:
         network_error = reply.error()
         error_string = reply.errorString()
-        _fail(f"Download failed (network error {int(network_error)}): {error_string}")
+        _fail(f"Download failed (network error {network_error}): {error_string}")
     if status_code not in (200, 206):
         _fail(f"Download failed (HTTP {status_code})")
 

--- a/kumoy/upload/presigned.py
+++ b/kumoy/upload/presigned.py
@@ -238,7 +238,7 @@ def _await_upload(
         error_string = reply.errorString()
         reply.deleteLater()
         raise Exception(
-            f"Upload failed (network error {int(network_error)}): {error_string}"
+            f"Upload failed (network error {network_error}): {error_string}"
         )
     if status_code not in (200, 201, 204):
         error_body = bytes(reply.readAll().data()).decode("utf-8", errors="replace")

--- a/tests/test_remote_image_label.py
+++ b/tests/test_remote_image_label.py
@@ -1,0 +1,63 @@
+import pytest
+from qgis.PyQt.QtCore import QByteArray
+from qgis.PyQt.QtGui import QImage
+
+from plugin_dir.pyqt_version import Q_NETWORK_REPLY_ERROR
+
+
+class _FakeReply:
+    """QNetworkReply の最小スタブ。error() は Qt6 と同じ enum 値を返す"""
+
+    def __init__(self, error, data=b""):
+        self._error = error
+        self._data = QByteArray(data)
+
+    def error(self):
+        return self._error
+
+    def readAll(self):
+        return self._data
+
+    def deleteLater(self):
+        pass
+
+
+def _png_bytes() -> bytes:
+    from qgis.PyQt.QtCore import QBuffer
+
+    from plugin_dir.pyqt_version import Q_BUFFER_OPEN_MODE
+
+    img = QImage(4, 4, QImage.Format.Format_ARGB32)
+    img.fill(0xFF00FF00)
+    buf = QBuffer()
+    buf.open(Q_BUFFER_OPEN_MODE.WriteOnly)
+    assert img.save(buf, "PNG")
+    return bytes(buf.data())
+
+
+@pytest.mark.usefixtures("qgis_plugin_path")
+class TestRemoteImageLabelOnFinished:
+    def _label(self):
+        from plugin_dir.ui.remote_image_label import RemoteImageLabel
+
+        return RemoteImageLabel(size=(32, 32))
+
+    def test_successful_reply_is_not_treated_as_error(self):
+        # Qt6 では NoError が truthy なので、真偽値判定だと常に失敗扱いになる
+        label = self._label()
+        label._reply = _FakeReply(Q_NETWORK_REPLY_ERROR.NoError, _png_bytes())
+        label._on_finished()
+        assert label._img is not None
+        assert not label._img.isNull()
+
+    def test_failed_reply_keeps_placeholder(self):
+        label = self._label()
+        label._reply = _FakeReply(Q_NETWORK_REPLY_ERROR.HostNotFoundError)
+        label._on_finished()
+        assert label._img is None
+
+    def test_undecodable_body_keeps_placeholder(self):
+        label = self._label()
+        label._reply = _FakeReply(Q_NETWORK_REPLY_ERROR.NoError, b"not an image")
+        label._on_finished()
+        assert label._img is None

--- a/tests/test_remote_image_label.py
+++ b/tests/test_remote_image_label.py
@@ -1,8 +1,12 @@
 import pytest
-from qgis.PyQt.QtCore import QByteArray
+from qgis.PyQt.QtCore import QBuffer, QByteArray
 from qgis.PyQt.QtGui import QImage
 
-from plugin_dir.pyqt_version import Q_NETWORK_REPLY_ERROR
+from plugin_dir.pyqt_version import (
+    Q_BUFFER_OPEN_MODE,
+    Q_IMAGE_FORMAT,
+    Q_NETWORK_REPLY_ERROR,
+)
 
 
 class _FakeReply:
@@ -23,11 +27,7 @@ class _FakeReply:
 
 
 def _png_bytes() -> bytes:
-    from qgis.PyQt.QtCore import QBuffer
-
-    from plugin_dir.pyqt_version import Q_BUFFER_OPEN_MODE
-
-    img = QImage(4, 4, QImage.Format.Format_ARGB32)
+    img = QImage(4, 4, Q_IMAGE_FORMAT.Format_ARGB32)
     img.fill(0xFF00FF00)
     buf = QBuffer()
     buf.open(Q_BUFFER_OPEN_MODE.WriteOnly)

--- a/tests/test_resolve_avatar_url.py
+++ b/tests/test_resolve_avatar_url.py
@@ -1,0 +1,43 @@
+import pytest
+
+
+@pytest.mark.usefixtures("qgis_plugin_path")
+class TestResolveAvatarUrl:
+    """resolve_avatar_url が外部URLと自前パスを正しく扱うことを検証する"""
+
+    def _mod(self):
+        from plugin_dir.kumoy.api import user
+
+        return user
+
+    def test_external_https_url_is_returned_as_is(self):
+        url = "https://lh3.googleusercontent.com/a/abc123"
+        assert self._mod().resolve_avatar_url(url) == url
+
+    def test_external_http_url_is_returned_as_is(self):
+        url = "http://example.com/avatar.png"
+        assert self._mod().resolve_avatar_url(url) == url
+
+    def test_relative_path_is_prefixed_with_server_url(self, monkeypatch):
+        m = self._mod()
+        monkeypatch.setattr(
+            m.api_config,
+            "get_api_config",
+            lambda: m.api_config.ApiConfig(SERVER_URL="https://example.kumoy.io"),
+        )
+        assert (
+            m.resolve_avatar_url("/user-content/avatars/a.png")
+            == "https://example.kumoy.io/user-content/avatars/a.png"
+        )
+
+    def test_trailing_slash_in_server_url_does_not_duplicate(self, monkeypatch):
+        m = self._mod()
+        monkeypatch.setattr(
+            m.api_config,
+            "get_api_config",
+            lambda: m.api_config.ApiConfig(SERVER_URL="https://example.kumoy.io/"),
+        )
+        assert (
+            m.resolve_avatar_url("/user-content/avatars/a.png")
+            == "https://example.kumoy.io/user-content/avatars/a.png"
+        )

--- a/ui/dialog_account.py
+++ b/ui/dialog_account.py
@@ -169,9 +169,9 @@ class DialogAccount(QDialog):
         self.email_label.setText(email)
 
         if self.user_info.avatarImage:
-            config = api.config.get_api_config()
-            avatar_url = config.SERVER_URL + self.user_info.avatarImage
-            self.avatar_label.load(avatar_url)
+            self.avatar_label.load(
+                api.user.resolve_avatar_url(self.user_info.avatarImage)
+            )
         else:
             initials = self._create_initials(name)
             self.avatar_label.setText(initials)

--- a/ui/dialog_project_select.py
+++ b/ui/dialog_project_select.py
@@ -565,8 +565,9 @@ class ProjectSelectDialog(QDialog):
 
         # Set avatar image if available
         if user.avatarImage:
-            avatar_url = api.config.get_api_config().SERVER_URL + user.avatarImage
-            self.account_org_panel["avatar_label"].load(avatar_url)
+            self.account_org_panel["avatar_label"].load(
+                api.user.resolve_avatar_url(user.avatarImage)
+            )
         # if no image, set avatar initial
         elif len(user.name) > 0:
             initial = user.name[0].upper()

--- a/ui/remote_image_label.py
+++ b/ui/remote_image_label.py
@@ -5,6 +5,7 @@ from qgis.PyQt.QtWidgets import QLabel
 
 from ..pyqt_version import (
     Q_BUFFER_OPEN_MODE,
+    Q_NETWORK_REPLY_ERROR,
     Q_REGION_TYPE,
     QT_ALIGN,
     QT_ASPECT_RATIO_MODE,
@@ -31,7 +32,9 @@ class RemoteImageLabel(QLabel):
         self._reply.finished.connect(self._on_finished)
 
     def _on_finished(self):
-        if self._reply.error():
+        # Qt6 exposes error codes as plain enum members, so NoError is truthy.
+        # Compare explicitly instead of relying on truthiness
+        if self._reply.error() != Q_NETWORK_REPLY_ERROR.NoError:
             self.setPixmap(placeholder_pixmap)
             self._reply.deleteLater()
             return


### PR DESCRIPTION
## 背景

MIERUNE/kumoy-services#2120 と同じ「アバターがリンク切れ」の症状をプラグイン側でも調べたところ、別の原因で **QGIS 4 では `RemoteImageLabel` の読み込みが全滅** していた。

## 修正内容

### 1. PyQt6のenum真偽値判定（本題）

PyQt6のQt enumは `enum.IntEnum` ではなく素の `enum.Enum` なので、値が0の `NoError` も truthy になる。

```python
>>> QNetworkReply.NetworkError.NoError
<NetworkError.NoError: 0>
>>> bool(QNetworkReply.NetworkError.NoError)
True
```

`RemoteImageLabel._on_finished` の `if self._reply.error():` が成功時も真になり、取得に成功していても即プレースホルダへ戻していた。アバター・組織アイコン・プロジェクトサムネイルすべてが対象。Qt5ではenumがintなのでQGIS 3系では露見しない。既存の互換定数 `Q_NETWORK_REPLY_ERROR.NoError` との明示比較に変更。

### 2. `int(network_error)` のTypeError

同じenum起因の潜在バグ。`kumoy/download.py` と `kumoy/upload/presigned.py` で、ネットワーク層のエラー時に `int(network_error)` が PyQt6 で `TypeError` を投げ、本来のエラーメッセージを潰していた。`int()` を外す（Qt5では従来どおり数値、Qt6では `NetworkError.HostNotFoundError` のように出る）。

### 3. `avatarImage` の外部URL対応

`GET /api/user/me` の `avatarImage` は、バックエンドの `withAvatarPath` により

- 自前ストレージ → `/user-content/<key>`（サーバ相対パス）
- 外部プロバイダ（Google等）→ **絶対URLのまま**

の2形態で返る。プラグインは `SERVER_URL + avatarImage` を無条件で連結していたため、Googleログインのユーザーで `https://app.kumoy.io/https://lh3.googleusercontent.com/...` になりリンク切れしていた（フロントエンドは `UserInformationSender.svelte` で同じ分岐を持っている）。`api.user.resolve_avatar_url()` に解決を集約し、呼び出し側2箇所（`ui/dialog_account.py`, `ui/dialog_project_select.py`）から利用する。`SERVER_URL` 末尾スラッシュの二重化も併せて解消。

## 検証

- **QGIS 4.2.0 / PyQt6 で実際のアバターURLを取得** → デコード成功（500x500）。修正前は `bool(NoError) is True` により必ずプレースホルダ
- QGIS 3.44 コンテナで全テスト: **186 passed, 1 skipped**
- `ruff format --check .` / `ruff check .` パス

新規テスト:

- `tests/test_remote_image_label.py` — `_on_finished` を偽リプライで直接検証（成功／ネットワークエラー／デコード不能）。真偽値判定に戻すとQt5/Qt6どちらでも落ちる
- `tests/test_resolve_avatar_url.py` — 外部URL素通し／相対パスへのSERVER_URL付与／末尾スラッシュ二重化なし

UI文字列の追加・変更は無いため `i18n/extract.py` の実行は不要。

## 残課題（本PRでは未修正）

`ui/layers/_upload_vector.py:89` と `ui/layers/_upload_raster.py:174` の `kumoy_layer.error() if kumoy_layer.error() else "Unknown error"` は `QgsError` オブジェクトの真偽値判定で常に truthy になるため、エラー無しの時に "Unknown error" ではなく空文字列になる。同種の問題だが今回の症状とは無関係なので分離した。
